### PR TITLE
fix(apply): correct condition for setting --impure with commit messages

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -282,7 +282,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	generationTag = strings.TrimSpace(generationTag)
 
-	if generationTag == "" {
+	if generationTag != "" {
 		// Make sure --impure is added to the Nix options if
 		// an implicit commit message is used.
 		if err := cmd.Flags().Set("impure", "true"); err != nil {


### PR DESCRIPTION
Oops. Turns out I was only setting `--impure` if the generation tag was EMPTY! That's moronic, and I'm surprised I haven't caught this earlier during testing :{