### PR TITLE
fix(install): use cobra.Command to set include flag for nixos-config value

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -115,8 +115,8 @@ This command also forwards Nix options passed here to all relevant Nix invocatio
 Check the Nix manual page for more details on what options are available.
 `
 
-	cmdUtils.SetHelpFlagText(&cmd)
 	cmd.SetHelpTemplate(helpTemplate)
+	cmdUtils.SetHelpFlagText(&cmd)
 
 	return &cmd
 }
@@ -406,8 +406,14 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 	}
 
 	if c, ok := nixConfig.(*configuration.LegacyConfiguration); ok {
-		opts.NixOptions.Includes = append(opts.NixOptions.Includes, fmt.Sprintf("nixos-config=%s", c.ConfigDirname))
+		// This value gets appended to the list of includes,
+		// and does not replace existing values already provided
+		// for -I on the command line.
+		if err := cmd.Flags().Set("include", fmt.Sprintf("nixos-config=%s", c.ConfigDirname)); err != nil {
+			panic("failed to set --include flag for nixos install command for legacy systems")
+		}
 	}
+
 	systemBuildOptions := configuration.SystemBuildOptions{
 		Verbose:   opts.Verbose,
 		CmdFlags:  cmd.Flags(),


### PR DESCRIPTION
The `nixos-config=` value was not getting copied into the command array for `nixos install`, since it was not set in the actual `cobra.Command` pflag set for the `install` subcommand. Because of this, the translation layer ignored the value for the `include` flag for the `nixos-config=` value and thus was installing the WRONG CONFIGURATION into the destination.

As such, this is a HUGE problem with legacy installs, I should have tested this better, unfortunately.

This PR sets the flag properly using the pflag `Set()` construct.