### PR TITLE
refactor(log): generalize interface and add new log types

### DIFF
--- a/cmd/activate/run.go
+++ b/cmd/activate/run.go
@@ -104,7 +104,7 @@ func getRequiredVars() (*RequiredVars, error) {
 
 func execInSwitchContext(
 	s system.CommandRunner,
-	log *logger.Logger,
+	log logger.Logger,
 	action activation.SwitchToConfigurationAction,
 	specialisation string,
 ) error {

--- a/cmd/activate/run.go
+++ b/cmd/activate/run.go
@@ -382,7 +382,11 @@ func activateMain(cmd *cobra.Command, opts *cmdOpts.ActivateOpts) error {
 	}
 	defer func() { _ = unix.Flock(int(lockfile.Fd()), unix.LOCK_UN) }()
 
-	// TODO: syslog init?
+	if syslogLogger, err := logger.NewSyslogLogger("nixos-cli-activate"); err == nil {
+		log = logger.NewMultiLogger(log, syslogLogger)
+	} else {
+		log.Warnf("failed to initialize syslog logger: %v", err)
+	}
 
 	if skipCheck := os.Getenv("NIXOS_NO_CHECK"); skipCheck == "" {
 		log.Info("running pre-switch checks")

--- a/cmd/activate/user.go
+++ b/cmd/activate/user.go
@@ -38,7 +38,7 @@ func execUserSwitchProcess(uid uint32, gid uint32, runtimePath string) error {
 	return cmd.Run()
 }
 
-func userSwitch(log *logger.Logger, parentExe string) error {
+func userSwitch(log logger.Logger, parentExe string) error {
 	childExe, err := filepath.EvalSymlinks("/proc/self/exe")
 	if err != nil {
 		log.Errorf("failed to get path of exe: %v", err)

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -336,7 +336,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	log.Step("Comparing changes...")
 
-	err = generation.RunDiffCommand(log, s, constants.CurrentSystem, resultLocation, &generation.DiffCommandOptions{
+	err = generation.RunDiffCommand(s, constants.CurrentSystem, resultLocation, &generation.DiffCommandOptions{
 		UseNvd:  cfg.UseNvd,
 		Verbose: opts.Verbose,
 	})

--- a/cmd/enter/enter.go
+++ b/cmd/enter/enter.go
@@ -5,6 +5,7 @@ import (
 
 	cmdOpts "github.com/nix-community/nixos-cli/internal/cmd/opts"
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
+	"github.com/nix-community/nixos-cli/internal/logger"
 )
 
 func EnterCommand() *cobra.Command {
@@ -14,12 +15,23 @@ func EnterCommand() *cobra.Command {
 		Use:   "enter [flags] [-- ARGS...]",
 		Short: "Chroot into a NixOS installation",
 		Long:  "Enter a NixOS chroot environment.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				opts.CommandArray = args
 			}
 
 			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			log := logger.FromContext(ctx)
+
+			if opts.Verbose {
+				log.SetLogLevel(logger.LogLevelDebug)
+			}
+
+			ctx = logger.WithLogger(ctx, log)
+			cmd.SetContext(ctx)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdUtils.CommandErrorHandler(enterMain(cmd, &opts))

--- a/cmd/enter/run.go
+++ b/cmd/enter/run.go
@@ -157,7 +157,7 @@ resolvConfDone:
 
 const NIXOS_REEXEC = "_NIXOS_ENTER_REEXEC"
 
-func execSandboxedEnterProcess(log *logger.Logger, verbose bool) error {
+func execSandboxedEnterProcess(log logger.Logger, verbose bool) error {
 	if verbose {
 		log.Infof("sandboxing process with unshare")
 	}

--- a/cmd/generation/diff/diff.go
+++ b/cmd/generation/diff/diff.go
@@ -73,7 +73,7 @@ func generationDiffMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, opt
 	beforeDirectory := filepath.Join(profileDirectory, fmt.Sprintf("%v-%v-link", genOpts.ProfileName, opts.Before))
 	afterDirectory := filepath.Join(profileDirectory, fmt.Sprintf("%v-%v-link", genOpts.ProfileName, opts.After))
 
-	err := generation.RunDiffCommand(log, s, beforeDirectory, afterDirectory, &generation.DiffCommandOptions{
+	err := generation.RunDiffCommand(s, beforeDirectory, afterDirectory, &generation.DiffCommandOptions{
 		UseNvd:  cfg.UseNvd,
 		Verbose: opts.Verbose,
 	})

--- a/cmd/generation/diff/diff.go
+++ b/cmd/generation/diff/diff.go
@@ -43,6 +43,17 @@ func GenerationDiffCommand(genOpts *cmdOpts.GenerationOpts) *cobra.Command {
 			return nil
 		},
 		ValidArgsFunction: generation.CompleteGenerationNumber(&genOpts.ProfileName, 2),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			log := logger.FromContext(ctx)
+
+			if opts.Verbose {
+				log.SetLogLevel(logger.LogLevelDebug)
+			}
+
+			ctx = logger.WithLogger(ctx, log)
+			cmd.SetContext(ctx)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdUtils.CommandErrorHandler(generationDiffMain(cmd, genOpts, &opts))
 		},
@@ -74,8 +85,7 @@ func generationDiffMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, opt
 	afterDirectory := filepath.Join(profileDirectory, fmt.Sprintf("%v-%v-link", genOpts.ProfileName, opts.After))
 
 	err := generation.RunDiffCommand(s, beforeDirectory, afterDirectory, &generation.DiffCommandOptions{
-		UseNvd:  cfg.UseNvd,
-		Verbose: opts.Verbose,
+		UseNvd: cfg.UseNvd,
 	})
 	if err != nil {
 		log.Errorf("failed to run diff command: %v", err)

--- a/cmd/generation/list/tui.go
+++ b/cmd/generation/list/tui.go
@@ -209,7 +209,7 @@ func clearScreen() {
 	fmt.Print(CLEAR + MV_TOP_LEFT)
 }
 
-func runGenerationSwitchCmd(log *logger.Logger, generation uint64, profile string) error {
+func runGenerationSwitchCmd(log logger.Logger, generation uint64, profile string) error {
 	argv := []string{os.Args[0], "generation", "-p", profile, "switch", fmt.Sprintf("%v", generation)}
 
 	cmd := exec.Command(argv[0], argv[1:]...)
@@ -223,7 +223,7 @@ func runGenerationSwitchCmd(log *logger.Logger, generation uint64, profile strin
 	return cmd.Run()
 }
 
-func runGenerationDeleteCmd(log *logger.Logger, generations []uint64, profile string) error {
+func runGenerationDeleteCmd(log logger.Logger, generations []uint64, profile string) error {
 	argv := []string{os.Args[0], "generation", "-p", profile, "delete"}
 	for _, v := range generations {
 		argv = append(argv, fmt.Sprintf("%v", v))
@@ -293,7 +293,7 @@ func newGenerationList(generations []generation.Generation) list.Model {
 	return l
 }
 
-func generationUI(log *logger.Logger, profile string, generations []generation.Generation) error {
+func generationUI(log logger.Logger, profile string, generations []generation.Generation) error {
 	closeLogFile, _ := cmdUtils.ConfigureBubbleTeaLogger("genlist")
 	defer closeLogFile()
 

--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -73,7 +73,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 
 	log.Step("Comparing changes...")
 
-	err = generation.RunDiffCommand(log, s, constants.CurrentSystem, generationLink, &generation.DiffCommandOptions{
+	err = generation.RunDiffCommand(s, constants.CurrentSystem, generationLink, &generation.DiffCommandOptions{
 		UseNvd:  cfg.UseNvd,
 		Verbose: opts.Verbose,
 	})
@@ -172,7 +172,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 	return nil
 }
 
-func findPreviousGeneration(log *logger.Logger, profileName string) (*generation.Generation, error) {
+func findPreviousGeneration(log logger.Logger, profileName string) (*generation.Generation, error) {
 	generations, err := genUtils.LoadGenerations(log, profileName, false)
 	if err != nil {
 		return nil, err

--- a/cmd/generation/shared/utils.go
+++ b/cmd/generation/shared/utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/logger"
 )
 
-func LoadGenerations(log *logger.Logger, profileName string, reverse bool) ([]generation.Generation, error) {
+func LoadGenerations(log logger.Logger, profileName string, reverse bool) ([]generation.Generation, error) {
 	generations, err := generation.CollectGenerationsInProfile(log, profileName)
 	if err != nil {
 		switch v := err.(type) {

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -125,7 +125,7 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 
 	log.Step("Comparing changes...")
 
-	err := generation.RunDiffCommand(log, s, constants.CurrentSystem, generationLink, &generation.DiffCommandOptions{
+	err := generation.RunDiffCommand(s, constants.CurrentSystem, generationLink, &generation.DiffCommandOptions{
 		UseNvd:  cfg.UseNvd,
 		Verbose: opts.Verbose,
 	})

--- a/cmd/init/cpuinfo.go
+++ b/cmd/init/cpuinfo.go
@@ -36,7 +36,7 @@ func (c CPUManufacturer) CPUType() string {
 	}
 }
 
-func getCPUInfo(log *logger.Logger) *CPUInfo {
+func getCPUInfo(log logger.Logger) *CPUInfo {
 	result := &CPUInfo{
 		VirtualisationEnabled: false,
 		Manufacturer:          manufacturerUnknown,
@@ -108,7 +108,9 @@ func (v VirtualisationType) String() string {
 	}
 }
 
-func determineVirtualisationType(s system.CommandRunner, log *logger.Logger) VirtualisationType {
+func determineVirtualisationType(s system.CommandRunner) VirtualisationType {
+	log := s.Logger()
+
 	cmd := system.NewCommand("systemd-detect-virt")
 
 	var stdout bytes.Buffer

--- a/cmd/init/devices.go
+++ b/cmd/init/devices.go
@@ -45,7 +45,7 @@ var (
 	}
 )
 
-func findPCIDevices(h *hardwareConfigSettings, log *logger.Logger) {
+func findPCIDevices(h *hardwareConfigSettings, log logger.Logger) {
 	entries, err := os.ReadDir(pciDeviceDirname)
 	if err != nil {
 		log.Warnf("failed to read %v: %v", pciDeviceDirname, err)
@@ -120,7 +120,7 @@ findDevices:
 	}
 }
 
-func findUSBDevices(h *hardwareConfigSettings, log *logger.Logger) {
+func findUSBDevices(h *hardwareConfigSettings, log logger.Logger) {
 	entries, err := os.ReadDir(usbDeviceDirname)
 	if err != nil {
 		log.Warnf("failed to read %s: %v", usbDeviceDirname, err)
@@ -148,7 +148,7 @@ func findUSBDevices(h *hardwareConfigSettings, log *logger.Logger) {
 	}
 }
 
-func findGenericDevicesInDir(h *hardwareConfigSettings, log *logger.Logger, deviceDirname string) {
+func findGenericDevicesInDir(h *hardwareConfigSettings, log logger.Logger, deviceDirname string) {
 	entries, err := os.ReadDir(deviceDirname)
 	if err != nil {
 		log.Warnf("failed to read %v: %v", deviceDirname, err)

--- a/cmd/init/filesystems.go
+++ b/cmd/init/filesystems.go
@@ -34,7 +34,7 @@ type LUKSInformation struct {
 	DevicePath string
 }
 
-func findSwapDevices(log *logger.Logger) []string {
+func findSwapDevices(log logger.Logger) []string {
 	swapDevices := []string{}
 
 	swapDeviceList, err := os.Open(swapDeviceListFilename)
@@ -67,7 +67,7 @@ func findSwapDevices(log *logger.Logger) []string {
 	return swapDevices
 }
 
-func findFilesystems(log *logger.Logger, rootDir string) []Filesystem {
+func findFilesystems(log logger.Logger, rootDir string) []Filesystem {
 	filesystems := []Filesystem{}
 
 	foundFileystems := make(map[string]string, 0)
@@ -219,7 +219,9 @@ func findFilesystems(log *logger.Logger, rootDir string) []Filesystem {
 	return filesystems
 }
 
-func lvmDevicesExist(s system.CommandRunner, log *logger.Logger) bool {
+func lvmDevicesExist(s system.CommandRunner) bool {
+	log := s.Logger()
+
 	cmd := system.NewCommand("lsblk", "-o", "TYPE")
 
 	var stdout bytes.Buffer
@@ -238,7 +240,7 @@ func lvmDevicesExist(s system.CommandRunner, log *logger.Logger) bool {
 	return strings.Contains(stdout.String(), "lvm")
 }
 
-func bcachefsFilesystemsExist(log *logger.Logger) bool {
+func bcachefsFilesystemsExist(log logger.Logger) bool {
 	entries, err := os.ReadDir("/dev")
 	if err != nil {
 		log.Warnf("failed to read /dev: %v", err)

--- a/cmd/init/generate.go
+++ b/cmd/init/generate.go
@@ -27,7 +27,9 @@ var configurationNixTemplate string
 //go:embed flake.nix.txt
 var flakeNixTemplate string
 
-func generateHwConfigNix(s system.CommandRunner, log *logger.Logger, cfg *settings.Settings, virtType VirtualisationType, opts *cmdOpts.InitOpts) (string, error) {
+func generateHwConfigNix(s system.CommandRunner, cfg *settings.Settings, virtType VirtualisationType, opts *cmdOpts.InitOpts) (string, error) {
+	log := s.Logger()
+
 	imports := []string{}
 	initrdAvailableModules := []string{}
 	initrdModules := []string{}
@@ -114,7 +116,7 @@ func generateHwConfigNix(s system.CommandRunner, log *logger.Logger, cfg *settin
 		networkInterfaceLines = append(networkInterfaceLines, fmt.Sprintf("  # networking.interfaces.%v.useDHCP = lib.mkDefault true;", i))
 	}
 
-	if lvmDevicesExist(s, log) {
+	if lvmDevicesExist(s) {
 		initrdModules = append(initrdModules, "dm-snapshot")
 	}
 
@@ -172,7 +174,7 @@ func generateHwConfigNix(s system.CommandRunner, log *logger.Logger, cfg *settin
 	), nil
 }
 
-func generateConfigNix(log *logger.Logger, cfg *settings.Settings, virtType VirtualisationType) (string, error) {
+func generateConfigNix(log logger.Logger, cfg *settings.Settings, virtType VirtualisationType) (string, error) {
 	var bootloaderConfig string
 
 	if _, err := os.Stat("/sys/firmware/efi/efivars"); err == nil {

--- a/cmd/init/run.go
+++ b/cmd/init/run.go
@@ -20,11 +20,11 @@ func initMain(cmd *cobra.Command, opts *cmdOpts.InitOpts) error {
 	cfg := settings.FromContext(cmd.Context())
 	s := system.NewLocalSystem(log)
 
-	virtType := determineVirtualisationType(s, log)
+	virtType := determineVirtualisationType(s)
 
 	log.Step("Generating hardware-configuration.nix...")
 
-	hwConfigNixText, err := generateHwConfigNix(s, log, cfg, virtType, opts)
+	hwConfigNixText, err := generateHwConfigNix(s, cfg, virtType, opts)
 	if err != nil {
 		log.Errorf("failed to generate hardware-configuration.nix: %v", err)
 		return err

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -121,7 +121,7 @@ Check the Nix manual page for more details on what options are available.
 	return &cmd
 }
 
-func validateMountpoint(log *logger.Logger, mountpoint string) error {
+func validateMountpoint(log logger.Logger, mountpoint string) error {
 	stat, err := os.Stat(mountpoint)
 	if err != nil {
 		log.Errorf("failed to stat %v: %v", mountpoint, err)
@@ -170,7 +170,9 @@ const (
 	defaultExtraSubstituters = "auto?trusted=1"
 )
 
-func copyChannel(cobraCmd *cobra.Command, s system.CommandRunner, log *logger.Logger, mountpoint string, channelDirectory string, buildOptions any, verbose bool) error {
+func copyChannel(cobraCmd *cobra.Command, s system.CommandRunner, mountpoint string, channelDirectory string, buildOptions any, verbose bool) error {
+	log := s.Logger()
+
 	mountpointChannelDir := filepath.Join(mountpoint, constants.NixChannelDirectory)
 
 	channelPath := channelDirectory
@@ -395,7 +397,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 
 	log.Step("Copying channel...")
 
-	err = copyChannel(cmd, s, log, mountpoint, opts.Channel, opts.NixOptions, opts.Verbose)
+	err = copyChannel(cmd, s, mountpoint, opts.Channel, opts.NixOptions, opts.Verbose)
 	if err != nil {
 		return err
 	}

--- a/cmd/option/completion.go
+++ b/cmd/option/completion.go
@@ -16,7 +16,7 @@ import (
 func loadOptions(log logger.Logger, cfg *settings.Settings, includes []string) (option.NixosOptionSource, error) {
 	s := system.NewLocalSystem(log)
 
-	nixosConfig, err := configuration.FindConfiguration(log, cfg, includes, false)
+	nixosConfig, err := configuration.FindConfiguration(log, cfg, includes)
 	if err != nil {
 		log.Errorf("failed to find configuration: %v", err)
 		return nil, err

--- a/cmd/option/completion.go
+++ b/cmd/option/completion.go
@@ -13,7 +13,7 @@ import (
 	"github.com/water-sucks/optnix/option"
 )
 
-func loadOptions(log *logger.Logger, cfg *settings.Settings, includes []string) (option.NixosOptionSource, error) {
+func loadOptions(log logger.Logger, cfg *settings.Settings, includes []string) (option.NixosOptionSource, error) {
 	s := system.NewLocalSystem(log)
 
 	nixosConfig, err := configuration.FindConfiguration(log, cfg, includes, false)

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -108,7 +108,7 @@ func optionMain(cmd *cobra.Command, opts *cmdOpts.OptionOpts) error {
 			return err
 		}
 	} else {
-		c, err := configuration.FindConfiguration(log, cfg, opts.NixPathIncludes, false)
+		c, err := configuration.FindConfiguration(log, cfg, opts.NixPathIncludes)
 		if err != nil {
 			log.Errorf("failed to find configuration: %v", err)
 			return err

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -134,7 +134,7 @@ func replMain(cmd *cobra.Command, opts *cmdOpts.ReplOpts) error {
 	if opts.FlakeRef != "" {
 		nixConfig = configuration.FlakeRefFromString(opts.FlakeRef)
 	} else {
-		c, err := configuration.FindConfiguration(log, cfg, opts.NixPathIncludes, false)
+		c, err := configuration.FindConfiguration(log, cfg, opts.NixPathIncludes)
 		if err != nil {
 			log.Errorf("failed to find configuration: %v", err)
 			return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -55,7 +55,7 @@ Flags:
 func mainCommand() (*cobra.Command, error) {
 	opts := cmdOpts.MainOpts{}
 
-	log := logger.NewLogger()
+	log := logger.NewConsoleLogger()
 	cmdCtx := logger.WithLogger(context.Background(), log)
 
 	configLocation := os.Getenv("NIXOS_CLI_CONFIG")

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -41,7 +41,7 @@ func (e *AttributeEvaluationError) Error() string {
 	return fmt.Sprintf("failed to evaluate attribute %s", e.Attribute)
 }
 
-func FindConfiguration(log *logger.Logger, cfg *settings.Settings, includes []string, verbose bool) (Configuration, error) {
+func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []string, verbose bool) (Configuration, error) {
 	if build.Flake() {
 		if verbose {
 			log.Info("looking for flake configuration")

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -15,7 +15,6 @@ type SystemBuildOptions struct {
 	DryBuild       bool
 	UseNom         bool
 	GenerationTag  string
-	Verbose        bool
 
 	// Command-line flags that were passed for the command context.
 	// This is needed to determine the proper Nix options to pass
@@ -41,11 +40,9 @@ func (e *AttributeEvaluationError) Error() string {
 	return fmt.Sprintf("failed to evaluate attribute %s", e.Attribute)
 }
 
-func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []string, verbose bool) (Configuration, error) {
+func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []string) (Configuration, error) {
 	if build.Flake() {
-		if verbose {
-			log.Info("looking for flake configuration")
-		}
+		log.Debug("looking for flake configuration")
 
 		f, err := FlakeRefFromEnv(cfg.ConfigLocation)
 		if err != nil {
@@ -56,20 +53,16 @@ func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []str
 			return nil, err
 		}
 
-		if verbose {
-			log.Infof("found flake configuration: %s#%s", f.URI, f.System)
-		}
+		log.Debugf("found flake configuration: %s#%s", f.URI, f.System)
 
 		return f, nil
 	} else {
-		c, err := FindLegacyConfiguration(log, includes, verbose)
+		c, err := FindLegacyConfiguration(log, includes)
 		if err != nil {
 			return nil, err
 		}
 
-		if verbose {
-			log.Infof("found legacy configuration at %s", c)
-		}
+		log.Debugf("found legacy configuration at %s", c.ConfigDirname)
 
 		return c, nil
 	}

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -21,7 +21,7 @@ type LegacyConfiguration struct {
 	Builder system.CommandRunner
 }
 
-func FindLegacyConfiguration(log *logger.Logger, includes []string, verbose bool) (*LegacyConfiguration, error) {
+func FindLegacyConfiguration(log logger.Logger, includes []string, verbose bool) (*LegacyConfiguration, error) {
 	if verbose {
 		log.Infof("looking for legacy configuration")
 	}

--- a/internal/generation/diff.go
+++ b/internal/generation/diff.go
@@ -7,8 +7,7 @@ import (
 )
 
 type DiffCommandOptions struct {
-	UseNvd  bool
-	Verbose bool
+	UseNvd bool
 }
 
 func RunDiffCommand(s system.CommandRunner, before string, after string, opts *DiffCommandOptions) error {
@@ -31,9 +30,7 @@ func RunDiffCommand(s system.CommandRunner, before string, after string, opts *D
 		argv = []string{"nvd", "diff", before, after}
 	}
 
-	if opts.Verbose {
-		s.Logger().CmdArray(argv)
-	}
+	s.Logger().CmdArray(argv)
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	_, err := s.Run(cmd)

--- a/internal/generation/diff.go
+++ b/internal/generation/diff.go
@@ -3,7 +3,6 @@ package generation
 import (
 	"os/exec"
 
-	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/system"
 )
 
@@ -12,7 +11,9 @@ type DiffCommandOptions struct {
 	Verbose bool
 }
 
-func RunDiffCommand(log *logger.Logger, s system.CommandRunner, before string, after string, opts *DiffCommandOptions) error {
+func RunDiffCommand(s system.CommandRunner, before string, after string, opts *DiffCommandOptions) error {
+	log := s.Logger()
+
 	useNvd := opts.UseNvd
 
 	if opts.UseNvd {
@@ -35,8 +36,6 @@ func RunDiffCommand(log *logger.Logger, s system.CommandRunner, before string, a
 	}
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
-
 	_, err := s.Run(cmd)
-
 	return err
 }

--- a/internal/generation/generation.go
+++ b/internal/generation/generation.go
@@ -146,7 +146,7 @@ const (
 	GenerationLinkTemplateRegex = `^%s-(\d+)-link$`
 )
 
-func CollectGenerationsInProfile(log *logger.Logger, profile string) ([]Generation, error) {
+func CollectGenerationsInProfile(log logger.Logger, profile string) ([]Generation, error) {
 	profileDirectory := constants.NixProfileDirectory
 	if profile != "system" {
 		profileDirectory = constants.NixSystemProfileDirectory

--- a/internal/generation/specialisations.go
+++ b/internal/generation/specialisations.go
@@ -96,7 +96,7 @@ func CompleteSpecialisationFlagFromConfig(flakeRefStr string, includes []string)
 		if flakeRefStr != "" {
 			nixConfig = configuration.FlakeRefFromString(flakeRefStr)
 		} else {
-			c, err := configuration.FindConfiguration(log, cfg, includes, false)
+			c, err := configuration.FindConfiguration(log, cfg, includes)
 			if err != nil {
 				log.Errorf("failed to find configuration: %v", err)
 				return []string{}, cobra.ShellCompDirectiveNoFileComp

--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -1,0 +1,134 @@
+package logger
+
+import (
+	"log"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/nix-community/nixos-cli/internal/utils"
+)
+
+type ConsoleLogger struct {
+	print *log.Logger
+	info  *log.Logger
+	warn  *log.Logger
+	error *log.Logger
+
+	level        LogLevel
+	stepNumber   uint
+	stepsEnabled bool
+}
+
+func NewConsoleLogger() *ConsoleLogger {
+	green := color.New(color.FgGreen)
+	boldYellow := color.New(color.FgYellow).Add(color.Bold)
+	boldRed := color.New(color.FgRed).Add(color.Bold)
+
+	return &ConsoleLogger{
+		print: log.New(os.Stderr, "", 0),
+		info:  log.New(os.Stderr, green.Sprint("info: "), 0),
+		warn:  log.New(os.Stderr, boldYellow.Sprint("warning: "), 0),
+		error: log.New(os.Stderr, boldRed.Sprint("error: "), 0),
+
+		stepNumber:   0,
+		stepsEnabled: os.Getenv("NIXOS_CLI_DISABLE_STEPS") == "",
+	}
+}
+
+func (l *ConsoleLogger) SetLogLevel(level LogLevel) {
+	l.level = level
+}
+
+func (l *ConsoleLogger) Print(v ...any) {
+	l.print.Print(v...)
+}
+
+func (l *ConsoleLogger) Printf(format string, v ...any) {
+	l.print.Printf(format, v...)
+}
+
+func (l *ConsoleLogger) Info(v ...any) {
+	if l.level > LogLevelInfo {
+		return
+	}
+	l.info.Println(v...)
+}
+
+func (l *ConsoleLogger) Infof(format string, v ...any) {
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	l.info.Printf(format+"\n", v...)
+}
+
+func (l *ConsoleLogger) Warn(v ...any) {
+	if l.level > LogLevelWarn {
+		return
+	}
+
+	l.warn.Println(v...)
+}
+
+func (l *ConsoleLogger) Warnf(format string, v ...any) {
+	if l.level > LogLevelWarn {
+		return
+	}
+
+	l.warn.Printf(format+"\n", v...)
+}
+
+func (l *ConsoleLogger) Error(v ...any) {
+	if l.level > LogLevelError {
+		return
+	}
+
+	l.error.Println(v...)
+}
+
+func (l *ConsoleLogger) Errorf(format string, v ...any) {
+	if l.level > LogLevelError {
+		return
+	}
+
+	l.error.Printf(format+"\n", v...)
+}
+
+func (l *ConsoleLogger) CmdArray(argv []string) {
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	msg := color.New(color.FgBlue).Sprintf("$ %v", utils.EscapeAndJoinArgs(argv))
+	l.print.Printf("%v\n", msg)
+}
+
+func (l *ConsoleLogger) Step(message string) {
+	if !l.stepsEnabled {
+		l.Info(message)
+		return
+	}
+
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	l.stepNumber++
+	if l.stepNumber > 1 {
+		l.print.Println()
+	}
+
+	msg := color.New(color.FgMagenta).Add(color.Bold).Sprintf("%v. %v", l.stepNumber, message)
+	l.print.Println(msg)
+}
+
+// Call this when the colors have been enabled or disabled.
+func (l *ConsoleLogger) RefreshColorPrefixes() {
+	green := color.New(color.FgGreen)
+	boldYellow := color.New(color.FgYellow).Add(color.Bold)
+	boldRed := color.New(color.FgRed).Add(color.Bold)
+
+	l.info.SetPrefix(green.Sprint("info: "))
+	l.warn.SetPrefix(boldYellow.Sprint("warning: "))
+	l.error.SetPrefix(boldRed.Sprint("error: "))
+}

--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -99,7 +99,7 @@ func (l *ConsoleLogger) CmdArray(argv []string) {
 		return
 	}
 
-	msg := color.New(color.FgBlue).Sprintf("$ %v", utils.EscapeAndJoinArgs(argv))
+	msg := blue.Sprintf("$ %v", utils.EscapeAndJoinArgs(argv))
 	l.print.Printf("%v\n", msg)
 }
 

--- a/internal/logger/context.go
+++ b/internal/logger/context.go
@@ -6,14 +6,15 @@ type loggerCtxKeyType string
 
 const loggerCtxKey loggerCtxKeyType = "logger"
 
-func WithLogger(ctx context.Context, logger *Logger) context.Context {
+func WithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerCtxKey, logger)
 }
 
-func FromContext(ctx context.Context) *Logger {
-	logger, ok := ctx.Value(loggerCtxKey).(*Logger)
+func FromContext(ctx context.Context) Logger {
+	logger, ok := ctx.Value(loggerCtxKey).(Logger)
 	if !ok {
 		panic("logger not present in context")
 	}
+
 	return logger
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -3,14 +3,17 @@ package logger
 type LogLevel int
 
 const (
-	LogLevelInfo   LogLevel = 0
-	LogLevelWarn   LogLevel = 1
-	LogLevelError  LogLevel = 2
-	LogLevelSilent LogLevel = 3
+	LogLevelDebug LogLevel = 0
+	LogLevelInfo  LogLevel = 1
+	LogLevelWarn  LogLevel = 2
+	LogLevelError LogLevel = 3
 )
 
 type Logger interface {
 	SetLogLevel(level LogLevel)
+	GetLogLevel() LogLevel
+	Debug(v ...any)
+	Debugf(format string, v ...any)
 	Info(v ...any)
 	Infof(format string, v ...any)
 	Warn(v ...any)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,24 +1,5 @@
 package logger
 
-import (
-	"log"
-	"os"
-
-	"github.com/fatih/color"
-	"github.com/nix-community/nixos-cli/internal/utils"
-)
-
-type Logger struct {
-	print *log.Logger
-	info  *log.Logger
-	warn  *log.Logger
-	error *log.Logger
-
-	level        LogLevel
-	stepNumber   uint
-	stepsEnabled bool
-}
-
 type LogLevel int
 
 const (
@@ -28,114 +9,16 @@ const (
 	LogLevelSilent LogLevel = 3
 )
 
-func NewLogger() *Logger {
-	green := color.New(color.FgGreen)
-	boldYellow := color.New(color.FgYellow).Add(color.Bold)
-	boldRed := color.New(color.FgRed).Add(color.Bold)
-
-	return &Logger{
-		print:      log.New(os.Stderr, "", 0),
-		info:       log.New(os.Stderr, green.Sprint("info: "), 0),
-		warn:       log.New(os.Stderr, boldYellow.Sprint("warning: "), 0),
-		error:      log.New(os.Stderr, boldRed.Sprint("error: "), 0),
-		stepNumber: 0,
-		// Some commands call other subcommands through forks, such.
-		// as `install` calling `enter`. For those, step numbers can
-		// be confusing.
-		stepsEnabled: os.Getenv("NIXOS_CLI_DISABLE_STEPS") == "",
-	}
-}
-
-func (l *Logger) Print(v ...any) {
-	l.print.Print(v...)
-}
-
-func (l *Logger) Printf(format string, v ...any) {
-	l.print.Printf(format, v...)
-}
-
-func (l *Logger) Info(v ...any) {
-	if l.level > LogLevelInfo {
-		return
-	}
-	l.info.Println(v...)
-}
-
-func (l *Logger) Infof(format string, v ...any) {
-	if l.level > LogLevelInfo {
-		return
-	}
-	l.info.Printf(format+"\n", v...)
-}
-
-func (l *Logger) Warn(v ...any) {
-	if l.level > LogLevelWarn {
-		return
-	}
-	l.warn.Println(v...)
-}
-
-func (l *Logger) Warnf(format string, v ...any) {
-	if l.level > LogLevelWarn {
-		return
-	}
-	l.warn.Printf(format+"\n", v...)
-}
-
-func (l *Logger) Error(v ...any) {
-	if l.level > LogLevelError {
-		return
-	}
-	l.error.Println(v...)
-}
-
-func (l *Logger) Errorf(format string, v ...any) {
-	if l.level > LogLevelError {
-		return
-	}
-	l.error.Printf(format+"\n", v...)
-}
-
-func (l *Logger) CmdArray(argv []string) {
-	if l.level > LogLevelInfo {
-		return
-	}
-
-	msg := color.New(color.FgBlue).Sprintf("$ %v", utils.EscapeAndJoinArgs(argv))
-	l.print.Printf("%v\n", msg)
-}
-
-func (l *Logger) Step(message string) {
-	// Replace step numbers with generic l.Info() calls if
-	// steps are disabled, to increase clarity in steps.
-	if !l.stepsEnabled {
-		l.Info(message)
-		return
-	}
-
-	if l.level > LogLevelInfo {
-		return
-	}
-
-	l.stepNumber++
-	if l.stepNumber > 1 {
-		l.print.Println()
-	}
-	msg := color.New(color.FgMagenta).Add(color.Bold).Sprintf("%v. %v", l.stepNumber, message)
-	l.print.Println(msg)
-}
-
-func (l *Logger) SetLogLevel(level LogLevel) {
-	l.level = level
-}
-
-// Call this when the colors have been enabled or disabled.
-func (l *Logger) RefreshColorPrefixes() {
-	green := color.New(color.FgGreen)
-	boldYellow := color.New(color.FgYellow).Add(color.Bold)
-	boldRed := color.New(color.FgRed).Add(color.Bold)
-
-	l.info.SetPrefix(green.Sprint("info: "))
-	l.warn.SetPrefix(boldYellow.Sprint("warning: "))
-	l.error.SetPrefix(boldRed.Sprint("error: "))
+type Logger interface {
+	SetLogLevel(level LogLevel)
+	Info(v ...any)
+	Infof(format string, v ...any)
+	Warn(v ...any)
+	Warnf(format string, v ...any)
+	Error(v ...any)
+	Errorf(format string, v ...any)
+	Print(v ...any)
+	Printf(format string, v ...any)
+	CmdArray(argv []string)
+	Step(message string)
 }

--- a/internal/logger/multi.go
+++ b/internal/logger/multi.go
@@ -1,0 +1,76 @@
+package logger
+
+// MultiLogger fans out log calls to multiple underlying loggers.
+type MultiLogger struct {
+	loggers []Logger
+}
+
+func NewMultiLogger(loggers ...Logger) *MultiLogger {
+	return &MultiLogger{loggers: loggers}
+}
+
+func (m *MultiLogger) SetLogLevel(level LogLevel) {
+	for _, l := range m.loggers {
+		l.SetLogLevel(level)
+	}
+}
+
+func (m *MultiLogger) Print(v ...any) {
+	for _, l := range m.loggers {
+		l.Print(v...)
+	}
+}
+
+func (m *MultiLogger) Printf(format string, v ...any) {
+	for _, l := range m.loggers {
+		l.Printf(format, v...)
+	}
+}
+
+func (m *MultiLogger) Info(v ...any) {
+	for _, l := range m.loggers {
+		l.Info(v...)
+	}
+}
+
+func (m *MultiLogger) Infof(format string, v ...any) {
+	for _, l := range m.loggers {
+		l.Infof(format, v...)
+	}
+}
+
+func (m *MultiLogger) Warn(v ...any) {
+	for _, l := range m.loggers {
+		l.Warn(v...)
+	}
+}
+
+func (m *MultiLogger) Warnf(format string, v ...any) {
+	for _, l := range m.loggers {
+		l.Warnf(format, v...)
+	}
+}
+
+func (m *MultiLogger) Error(v ...any) {
+	for _, l := range m.loggers {
+		l.Error(v...)
+	}
+}
+
+func (m *MultiLogger) Errorf(format string, v ...any) {
+	for _, l := range m.loggers {
+		l.Errorf(format, v...)
+	}
+}
+
+func (m *MultiLogger) CmdArray(argv []string) {
+	for _, l := range m.loggers {
+		l.CmdArray(argv)
+	}
+}
+
+func (m *MultiLogger) Step(message string) {
+	for _, l := range m.loggers {
+		l.Step(message)
+	}
+}

--- a/internal/logger/multi.go
+++ b/internal/logger/multi.go
@@ -15,6 +15,22 @@ func (m *MultiLogger) SetLogLevel(level LogLevel) {
 	}
 }
 
+func (m *MultiLogger) GetLogLevel() LogLevel {
+	if len(m.loggers) == 0 {
+		return LogLevelInfo
+	}
+
+	minimumLevel := m.loggers[0].GetLogLevel()
+
+	for _, l := range m.loggers[1:] {
+		if lvl := l.GetLogLevel(); lvl < minimumLevel {
+			minimumLevel = lvl
+		}
+	}
+
+	return minimumLevel
+}
+
 func (m *MultiLogger) Print(v ...any) {
 	for _, l := range m.loggers {
 		l.Print(v...)
@@ -24,6 +40,18 @@ func (m *MultiLogger) Print(v ...any) {
 func (m *MultiLogger) Printf(format string, v ...any) {
 	for _, l := range m.loggers {
 		l.Printf(format, v...)
+	}
+}
+
+func (m *MultiLogger) Debug(v ...any) {
+	for _, l := range m.loggers {
+		l.Debug(v...)
+	}
+}
+
+func (m *MultiLogger) Debugf(format string, v ...any) {
+	for _, l := range m.loggers {
+		l.Debugf(format, v...)
 	}
 }
 

--- a/internal/logger/syslog.go
+++ b/internal/logger/syslog.go
@@ -17,7 +17,7 @@ type SyslogLogger struct {
 }
 
 func NewSyslogLogger(tag string) (*SyslogLogger, error) {
-	w, err := syslog.New(syslog.LOG_INFO|syslog.LOG_USER, tag)
+	w, err := syslog.New(syslog.LOG_DEBUG|syslog.LOG_USER, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -32,6 +32,26 @@ func NewSyslogLogger(tag string) (*SyslogLogger, error) {
 
 func (l *SyslogLogger) SetLogLevel(level LogLevel) {
 	l.level = level
+}
+
+func (l *SyslogLogger) GetLogLevel() LogLevel {
+	return l.level
+}
+
+func (l *SyslogLogger) Debug(v ...any) {
+	if l.level > LogLevelDebug {
+		return
+	}
+
+	_ = l.writer.Debug(fmt.Sprint(v...))
+}
+
+func (l *SyslogLogger) Debugf(format string, v ...any) {
+	if l.level > LogLevelDebug {
+		return
+	}
+
+	_ = l.writer.Debug(fmt.Sprintf(format, v...))
 }
 
 func (l *SyslogLogger) Print(v ...any) {
@@ -91,7 +111,7 @@ func (l *SyslogLogger) Errorf(format string, v ...any) {
 }
 
 func (l *SyslogLogger) CmdArray(argv []string) {
-	if l.level > LogLevelInfo {
+	if l.level > LogLevelDebug {
 		return
 	}
 

--- a/internal/logger/syslog.go
+++ b/internal/logger/syslog.go
@@ -1,0 +1,114 @@
+package logger
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+
+	"github.com/nix-community/nixos-cli/internal/utils"
+)
+
+type SyslogLogger struct {
+	writer *syslog.Writer
+
+	level        LogLevel
+	stepNumber   uint
+	stepsEnabled bool
+}
+
+func NewSyslogLogger(tag string) (*SyslogLogger, error) {
+	w, err := syslog.New(syslog.LOG_INFO|syslog.LOG_USER, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SyslogLogger{
+		writer:       w,
+		level:        LogLevelInfo,
+		stepNumber:   0,
+		stepsEnabled: os.Getenv("NIXOS_CLI_DISABLE_STEPS") == "",
+	}, nil
+}
+
+func (l *SyslogLogger) SetLogLevel(level LogLevel) {
+	l.level = level
+}
+
+func (l *SyslogLogger) Print(v ...any) {
+	_ = l.writer.Info(fmt.Sprint(v...))
+}
+
+func (l *SyslogLogger) Printf(format string, v ...any) {
+	_ = l.writer.Info(fmt.Sprintf(format, v...))
+}
+
+func (l *SyslogLogger) Info(v ...any) {
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	_ = l.writer.Info(fmt.Sprint(v...))
+}
+
+func (l *SyslogLogger) Infof(format string, v ...any) {
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	_ = l.writer.Info(fmt.Sprintf(format, v...))
+}
+
+func (l *SyslogLogger) Warn(v ...any) {
+	if l.level > LogLevelWarn {
+		return
+	}
+
+	_ = l.writer.Warning(fmt.Sprint(v...))
+}
+
+func (l *SyslogLogger) Warnf(format string, v ...any) {
+	if l.level > LogLevelWarn {
+		return
+	}
+
+	_ = l.writer.Warning(fmt.Sprintf(format, v...))
+}
+
+func (l *SyslogLogger) Error(v ...any) {
+	if l.level > LogLevelError {
+		return
+	}
+
+	_ = l.writer.Err(fmt.Sprint(v...))
+}
+
+func (l *SyslogLogger) Errorf(format string, v ...any) {
+	if l.level > LogLevelError {
+		return
+	}
+
+	_ = l.writer.Err(fmt.Sprintf(format, v...))
+}
+
+func (l *SyslogLogger) CmdArray(argv []string) {
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	_ = l.writer.Debug(fmt.Sprintf("$ %v", utils.EscapeAndJoinArgs(argv)))
+}
+
+func (l *SyslogLogger) Step(message string) {
+	if !l.stepsEnabled {
+		l.Info(message)
+		return
+	}
+
+	if l.level > LogLevelInfo {
+		return
+	}
+
+	l.stepNumber++
+	stepMsg := fmt.Sprintf("%v. %v", l.stepNumber, message)
+	_ = l.writer.Info(stepMsg)
+}

--- a/internal/system/local.go
+++ b/internal/system/local.go
@@ -11,10 +11,10 @@ import (
 )
 
 type LocalSystem struct {
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewLocalSystem(logger *logger.Logger) *LocalSystem {
+func NewLocalSystem(logger logger.Logger) *LocalSystem {
 	return &LocalSystem{
 		logger: logger,
 	}
@@ -68,7 +68,7 @@ func (l *LocalSystem) IsNixOS() bool {
 	return nixosDistroIDRegex.MatchString(distroID)
 }
 
-func (l *LocalSystem) Logger() *logger.Logger {
+func (l *LocalSystem) Logger() logger.Logger {
 	return l.logger
 }
 

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -9,7 +9,7 @@ import (
 
 type CommandRunner interface {
 	Run(cmd *Command) (int, error)
-	Logger() *logger.Logger
+	Logger() logger.Logger
 }
 
 type Command struct {


### PR DESCRIPTION
## Description

This PR improves logging facilities within `nixos-cli` in the following ways:

- Converts the `Logger` facility into an interface instead of a concrete console logger (this is implemented separately)
- Uses system logger whenever possible
- Handles verbosity automatically via the command line by setting a log level in the base logger
- Differentiates debug vs. info logs
- Adds a `SyslogLogger` implementation for `nixos activate`

Closes #110.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Syslog backend and colorized console logger added for richer, level-aware output.
  * Multi-output logger added to emit logs to multiple destinations simultaneously.

* **Improvements**
  * Unified logging: verbose flag consolidated into log levels (including debug).
  * Command output and step traces now consistently respect logger levels and appear reliably when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->