### PR TITLE
fix(completion): complete carapace transition

### DIFF
--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -211,8 +211,7 @@ func completeSpecialisationFlag(profileName string) cobra.CompletionFunc {
 	}
 
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// I was too lazy to not
-		log := logger.FromContext(cmd.Context())
+		log, _ := cmdUtils.PrepareCompletionResources()
 
 		previousGen, err := findPreviousGeneration(log, profileName)
 		if err != nil {

--- a/cmd/option/completion.go
+++ b/cmd/option/completion.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/nix-community/nixos-cli/internal/cmd/opts"
+	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/configuration"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
@@ -59,8 +60,7 @@ func loadOptions(log logger.Logger, cfg *settings.Settings, includes []string) (
 
 func OptionsCompletionFunc(opts *cmdOpts.OptionOpts) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		log := logger.FromContext(cmd.Context())
-		cfg := settings.FromContext(cmd.Context())
+		log, cfg := cmdUtils.PrepareCompletionResources()
 
 		if len(args) != 0 {
 			return []string{}, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/utils/completion.go
+++ b/internal/cmd/utils/completion.go
@@ -1,0 +1,34 @@
+package cmdUtils
+
+import (
+	"os"
+
+	"github.com/nix-community/nixos-cli/internal/constants"
+	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/settings"
+)
+
+// Prepare command resources that are needed for completion, but that
+// otherwise need to be retrieved from the Cobra command context.
+//
+// Only for use in carapace completion functions.
+func PrepareCompletionResources() (logger.Logger, *settings.Settings) {
+	var log logger.Logger
+	if debugMode := os.Getenv("NIXOS_CLI_DEBUG_MODE"); debugMode != "" {
+		log = logger.NewConsoleLogger()
+	} else {
+		log = logger.NewNoOpLogger()
+	}
+
+	configLocation := os.Getenv("NIXOS_CLI_CONFIG")
+	if configLocation == "" {
+		configLocation = constants.DefaultConfigLocation
+	}
+
+	cfg, err := settings.ParseSettings(configLocation)
+	if err != nil {
+		cfg = settings.NewSettings()
+	}
+
+	return log, cfg
+}

--- a/internal/generation/completion.go
+++ b/internal/generation/completion.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strconv"
 
+	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/constants"
-	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +40,7 @@ func CompleteProfileFlag(_ *cobra.Command, args []string, toComplete string) ([]
 
 func CompleteGenerationNumber(profile *string, limit int) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		log := logger.FromContext(cmd.Context())
+		log, _ := cmdUtils.PrepareCompletionResources()
 
 		if limit != 0 && len(args) >= limit {
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
@@ -80,7 +80,7 @@ func CompleteGenerationNumber(profile *string, limit int) cobra.CompletionFunc {
 
 func CompleteGenerationNumberFlag(profile *string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		log := logger.FromContext(cmd.Context())
+		log, _ := cmdUtils.PrepareCompletionResources()
 
 		generations, err := CollectGenerationsInProfile(log, *profile)
 		if err != nil {

--- a/internal/logger/noop.go
+++ b/internal/logger/noop.go
@@ -1,0 +1,37 @@
+package logger
+
+type NoOpLogger struct{}
+
+func NewNoOpLogger() NoOpLogger {
+	return NoOpLogger{}
+}
+
+func (n NoOpLogger) SetLogLevel(level LogLevel) {}
+
+func (n NoOpLogger) GetLogLevel() LogLevel {
+	return LogLevelDebug
+}
+
+func (n NoOpLogger) Print(v ...any) {}
+
+func (n NoOpLogger) Printf(format string, v ...any) {}
+
+func (n NoOpLogger) Debug(v ...any) {}
+
+func (n NoOpLogger) Debugf(format string, v ...any) {}
+
+func (n NoOpLogger) Info(v ...any) {}
+
+func (n NoOpLogger) Infof(format string, v ...any) {}
+
+func (n NoOpLogger) Warn(v ...any) {}
+
+func (n NoOpLogger) Warnf(format string, v ...any) {}
+
+func (n NoOpLogger) Error(v ...any) {}
+
+func (n NoOpLogger) Errorf(format string, v ...any) {}
+
+func (n NoOpLogger) CmdArray(argv []string) {}
+
+func (n NoOpLogger) Step(message string) {}


### PR DESCRIPTION
## Description

Some things were left over from the introduction of `carapace` for command-line completion in #99.

My fault.

Some completions were panicking because of the fact that `carapace` does not instantiate the logger and configuration context properly for those completion functions, so the lack of context would simply cause the whole completion to die and spit out an annoying stack trace.

Also, completions for aliases were screwed because `__complete` is a Cobra construct, not a `carapace` one, and thus, `carapace` did not understand the Cobra completion script's ouput and did nothing with it.

This PR resolves those issues by using `carapace` bridging functions for both of those facilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded shell completion infrastructure to use a modern completion framework
  * Improved internal resource management for completion operations
  * Consolidated logger and configuration retrieval for completion workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->