### PR TITLE
fix(completion): disable settings warning in completion mode

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -65,7 +65,7 @@ func mainCommand() (*cobra.Command, error) {
 
 	cfg, err := settings.ParseSettings(configLocation)
 	if err != nil {
-		if os.Getenv("NIXOS_CLI_SUPPRESS_NO_SETTINGS_WARNING") == "" {
+		if os.Getenv("NIXOS_CLI_SUPPRESS_NO_SETTINGS_WARNING") == "" && !carapace.IsCallback() {
 			log.Error(err)
 			log.Warn("proceeding with defaults only, you have been warned")
 		}


### PR DESCRIPTION
## Description

The no settings file warning mangles completion output, so disable it in completion mode.

Closes #117.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling to suppress unnecessary warnings when the CLI is used within shell completion contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->