### PR TITLE
fix(activate): warn first when attempting to cancel activation

### DIFF
--- a/cmd/activate/run.go
+++ b/cmd/activate/run.go
@@ -104,7 +104,7 @@ func getRequiredVars() (*RequiredVars, error) {
 }
 
 func execInSwitchContext(
-	s system.CommandRunner,
+	s system.System,
 	log logger.Logger,
 	action activation.SwitchToConfigurationAction,
 	specialisation string,

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -223,6 +223,8 @@ func SwitchToConfiguration(s system.CommandRunner, generationLocation string, ac
 		cmd.SetEnv("NIXOS_INSTALL_BOOTLOADER", "1")
 	}
 
+	cmd.ForwardSignals = false
+
 	cmd.SetEnv("NIXOS_CLI_ATTEMPTING_ACTIVATION", "1")
 	_, err := s.Run(cmd)
 	return err

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -14,22 +14,24 @@ type CommandRunner interface {
 }
 
 type Command struct {
-	Name   string
-	Args   []string
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
-	Env    map[string]string
+	Name           string
+	Args           []string
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
+	Env            map[string]string
+	ForwardSignals bool
 }
 
 func NewCommand(name string, args ...string) *Command {
 	return &Command{
-		Name:   name,
-		Args:   args,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		Env:    make(map[string]string),
+		Name:           name,
+		Args:           args,
+		Stdin:          os.Stdin,
+		Stdout:         os.Stdout,
+		Stderr:         os.Stderr,
+		Env:            make(map[string]string),
+		ForwardSignals: true,
 	}
 }
 


### PR DESCRIPTION
## Description

Canceling activation with SIGINT or SIGTERM is a dangerous thing for `nixos activate`, since essential services getting stopped and not restarted can leave the system in an unusable state, for example.

This prevents cancellation for `nixos activate` by printing a warning first, and then letting the user through if they do want to cancel it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented graceful three-tier shutdown protocol: initial signal displays warning, second signal initiates graceful cancellation, third signal forces termination
  * Added signal forwarding capability for spawned processes (enabled by default) to improve process control and responsiveness to system signals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->