### PR TITLE
feat(system): redo password handling for remote root, allow SSH password auth

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -1,7 +1,6 @@
 package apply
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -177,12 +176,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		log.Debugf("connecting to %s", opts.TargetHost)
 		host, err := system.NewSSHSystem(opts.TargetHost, log)
 		if err != nil {
-			if errors.Is(err, system.ErrAgentNotStarted) {
-				log.Errorf("an SSH agent is not running")
-				log.Info("you must add your identity key(s) to an SSH agent if using --target-host")
-			} else {
-				log.Errorf("%v", err)
-			}
+			log.Errorf("%v", err)
 			return err
 		}
 
@@ -231,12 +225,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		log.Debugf("connecting to %s", opts.BuildHost)
 		host, err := system.NewSSHSystem(opts.BuildHost, log)
 		if err != nil {
-			if errors.Is(err, system.ErrAgentNotStarted) {
-				log.Errorf("an SSH agent is not running")
-				log.Info("you must add your identity key(s) to an SSH agent if using --build-host")
-			} else {
-				log.Errorf("%v", err)
-			}
+			log.Errorf("%v", err)
 			return err
 		}
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -404,24 +404,24 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	}
 
 	if !opts.AlwaysConfirm {
-		// FIXME: Currently, the ConfirmationInput() function does not like
-		// taking input properly when the target host is remote, Because of this
-		// we should skip interactive confirmation here for now until this can get
-		// fixed.
-		if !targetHost.IsRemote() {
-			log.Printf("\n")
-			confirm, err := cmdUtils.ConfirmationInput("Activate this configuration?")
-			if err != nil {
-				log.Errorf("failed to get confirmation: %v", err)
-				return err
-			}
-			if !confirm {
-				msg := "confirmation was not given, skipping activation"
-				log.Warn(msg)
-				return fmt.Errorf("%v", msg)
-			}
-		} else {
-			log.Debug("skipping confirmation prompt since target is remote")
+		log.Printf("\n")
+		confirm, err := cmdUtils.ConfirmationInput("Activate this configuration?")
+		if err != nil {
+			log.Errorf("failed to get confirmation: %v", err)
+			return err
+		}
+		if !confirm {
+			msg := "confirmation was not given, skipping activation"
+			log.Warn(msg)
+			return fmt.Errorf("%v", msg)
+		}
+	}
+
+	if t, ok := targetHost.(*system.SSHSystem); ok && opts.RemoteRoot {
+		err = t.EnsureRemoteRootPassword(cfg.RootCommand)
+		if err != nil {
+			log.Error(err)
+			return err
 		}
 	}
 

--- a/doc/src/overview.md
+++ b/doc/src/overview.md
@@ -76,8 +76,25 @@ tabular, `grep`-able output like the old behavior of `nixos-rebuild` uses, use
 
 Default specialisations are managed through the `nixos-cli` configuration.
 
-In the future, setting build and target hosts for remote building/activation
-using SSH will be supported.
+#### Remote Deployments
+
+Remote building is supported by using `--build-host <HOST>`, where **HOST** is
+an SSH URL to a machine that can use Nix to build artifacts.
+
+Remote deployment is supported through the usage of two flags `--target-host`,
+and `--remote-root`, and is done over SSH.
+
+In order for remote deployments to succeed, a user with root escalation access
+(through usage of the `root_command` setting, for example `sudo`) or the root
+user must be used through SSH.
+
+If using a non-root user, the `--remote-root` flag must be used. This
+automatically escalates to `root` using the command defined in the
+`root_command` setting.
+
+In order to access remote machines, prefer using an SSH agent and keys. Password
+access is supported, but not recommended, and can be buggy. If you find any
+issues, report them on the issue tracker.
 
 ### `nixos-enter`
 


### PR DESCRIPTION
## Description

`sudo` and other root command input is just broken right now due to required interactive input.

As such, this changes around some SSH handling, and also allows passwords to be used as an authentication mechanism.
If a password is used for access, then this is reused when `--remote-sudo` is passed. Additionally, it asks for a password once, and then uses `sudo` stdin.

This may be broken for `doas`, and `doas` still requires command input and a PTY, but this is a step in the right direction.

Also, this removes passing `stdin` to SSH processes, since no remote commands should need a `stdin` at this time. This fixes some input handling for remote confirmation as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-based SSH authentication as a supported fallback when agent keys aren't available.
  * Automatic remote root password setup/verification when remote root escalation is requested.

* **Improvements**
  * SSH connection errors are consistently logged and surfaced.
  * Activation confirmation now prompts uniformly for all targets.

* **Documentation**
  * New "Remote Deployments" guide covering remote build/deploy flags, authentication, and root escalation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->