### PR TITLE
feat(apply): add image build option

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -68,6 +68,13 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 				}
 			}
 
+			// Set a special hidden _list value for this
+			// flag in order to list available images and
+			// exit.
+			if cmd.Flags().Changed("image") && opts.BuildImage == "" {
+				opts.BuildImage = "_list"
+			}
+
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -90,6 +97,7 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.InstallBootloader, "install-bootloader", false, "(Re)install the bootloader on the configured device(s)")
 	cmd.Flags().BoolVar(&opts.NoActivate, "no-activate", false, "Do not activate the built configuration")
 	cmd.Flags().BoolVar(&opts.NoBoot, "no-boot", false, "Do not create boot entry for this generation")
+	cmd.Flags().StringVarP(&opts.BuildImage, "image", "i", "", "Build a pre-configured disk-image `variant`")
 	cmd.Flags().StringVarP(&opts.OutputPath, "output", "o", "", "Symlink the output to `location`")
 	cmd.Flags().StringVarP(&opts.ProfileName, "profile-name", "p", "system", "Store generations using the profile `name`")
 	cmd.Flags().StringVarP(&opts.Specialisation, "specialisation", "s", "", "Activate the specialisation with `name`")
@@ -144,7 +152,7 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("dry", "output")
 	cmd.MarkFlagsMutuallyExclusive("output", "build-host")
 	cmd.MarkFlagsMutuallyExclusive("output", "target-host")
-	cmd.MarkFlagsMutuallyExclusive("vm", "vm-with-bootloader")
+	cmd.MarkFlagsMutuallyExclusive("vm", "vm-with-bootloader", "image")
 	cmd.MarkFlagsMutuallyExclusive("no-activate", "specialisation")
 
 	helpTemplate := cmd.HelpTemplate()

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -425,7 +425,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 
 	log.Step("Building system...")
 
-	resultLocation, err := nixConfig.BuildSystem(configuration.SystemBuildTypeSystem, &systemBuildOptions)
+	resultLocation, err := nixConfig.BuildSystem(&configuration.SystemBuild{}, &systemBuildOptions)
 	if err != nil {
 		log.Errorf("failed to build system: %v", err)
 		return err

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -115,6 +115,13 @@ global *--config* flag as such:
 
 	The list of changes is not guaranteed to be complete for dry activations.
 
+*-i*, *--image* <VARIANT>
+	Build a disk-image variant, pre-configured for the given platform/provider.
+
+	If *VARIANT* is not provided (i.e. passing _-i ""_), or an invalid one is
+	provided, then a list of available images is displayed, and the program
+	exits.
+
 *--install-bootloader*
 	(Re)install the bootloader to the configured target device(s). The
 	bootloader configuration is managed by their NixOS modules, so this behavior

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -29,6 +29,7 @@ type ApplyOpts struct {
 	FlakeRef              string
 	GenerationTag         string
 	InstallBootloader     bool
+	BuildImage            string
 	NoActivate            bool
 	NoBoot                bool
 	OutputPath            string

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -42,35 +42,37 @@ type ApplyOpts struct {
 	UseNom                bool
 	Verbose               bool
 
-	NixOptions struct {
-		Quiet                   bool              `nixCategory:"build"`
-		PrintBuildLogs          bool              `nixCategory:"build"`
-		NoBuildOutput           bool              `nixCategory:"build"`
-		ShowTrace               bool              `nixCategory:"build"`
-		KeepGoing               bool              `nixCategory:"build,copy"`
-		KeepFailed              bool              `nixCategory:"build,copy"`
-		Fallback                bool              `nixCategory:"build,copy"`
-		Refresh                 bool              `nixCategory:"build,copy"`
-		Repair                  bool              `nixCategory:"build,copy"`
-		Impure                  bool              `nixCategory:"build"`
-		Offline                 bool              `nixCategory:"build"`
-		NoNet                   bool              `nixCategory:"build"`
-		SubstituteOnDestination bool              `nixCategory:"build,copy"`
-		MaxJobs                 int               `nixCategory:"build,copy"`
-		Cores                   int               `nixCategory:"build,copy"`
-		Builders                []string          `nixCategory:"build"`
-		LogFormat               string            `nixCategory:"build,copy"`
-		Includes                []string          `nixCategory:"build"`
-		Options                 map[string]string `nixCategory:"build,copy"`
+	NixOptions ApplyNixOpts
+}
 
-		RecreateLockFile bool              `nixCategory:"lock"`
-		NoUpdateLockFile bool              `nixCategory:"lock"`
-		NoWriteLockFile  bool              `nixCategory:"lock"`
-		NoUseRegistries  bool              `nixCategory:"lock"`
-		CommitLockFile   bool              `nixCategory:"lock"`
-		UpdateInputs     []string          `nixCategory:"lock"`
-		OverrideInputs   map[string]string `nixCategory:"lock"`
-	}
+type ApplyNixOpts struct {
+	Quiet                   bool              `nixCategory:"build"`
+	PrintBuildLogs          bool              `nixCategory:"build"`
+	NoBuildOutput           bool              `nixCategory:"build"`
+	ShowTrace               bool              `nixCategory:"build"`
+	KeepGoing               bool              `nixCategory:"build,copy"`
+	KeepFailed              bool              `nixCategory:"build,copy"`
+	Fallback                bool              `nixCategory:"build,copy"`
+	Refresh                 bool              `nixCategory:"build,copy"`
+	Repair                  bool              `nixCategory:"build,copy"`
+	Impure                  bool              `nixCategory:"build"`
+	Offline                 bool              `nixCategory:"build"`
+	NoNet                   bool              `nixCategory:"build"`
+	SubstituteOnDestination bool              `nixCategory:"build,copy"`
+	MaxJobs                 int               `nixCategory:"build,copy"`
+	Cores                   int               `nixCategory:"build,copy"`
+	Builders                []string          `nixCategory:"build"`
+	LogFormat               string            `nixCategory:"build,copy"`
+	Includes                []string          `nixCategory:"build"`
+	Options                 map[string]string `nixCategory:"build,copy"`
+
+	RecreateLockFile bool              `nixCategory:"lock"`
+	NoUpdateLockFile bool              `nixCategory:"lock"`
+	NoWriteLockFile  bool              `nixCategory:"lock"`
+	NoUseRegistries  bool              `nixCategory:"lock"`
+	CommitLockFile   bool              `nixCategory:"lock"`
+	UpdateInputs     []string          `nixCategory:"lock"`
+	OverrideInputs   map[string]string `nixCategory:"lock"`
 }
 
 type EnterOpts struct {
@@ -156,33 +158,35 @@ type InstallOpts struct {
 	Verbose        bool
 	FlakeRef       *configuration.FlakeRef
 
-	NixOptions struct {
-		Quiet          bool
-		PrintBuildLogs bool
-		NoBuildOutput  bool
-		ShowTrace      bool
-		KeepGoing      bool
-		KeepFailed     bool
-		Fallback       bool
-		Refresh        bool
-		Repair         bool
-		Impure         bool
-		Offline        bool
-		NoNet          bool
-		MaxJobs        int
-		Cores          int
-		LogFormat      string
-		Includes       []string
-		Options        map[string]string
+	NixOptions InstallNixOpts
+}
 
-		RecreateLockFile bool
-		NoUpdateLockFile bool
-		NoWriteLockFile  bool
-		NoUseRegistries  bool
-		CommitLockFile   bool
-		UpdateInputs     []string
-		OverrideInputs   map[string]string
-	}
+type InstallNixOpts struct {
+	Quiet          bool
+	PrintBuildLogs bool
+	NoBuildOutput  bool
+	ShowTrace      bool
+	KeepGoing      bool
+	KeepFailed     bool
+	Fallback       bool
+	Refresh        bool
+	Repair         bool
+	Impure         bool
+	Offline        bool
+	NoNet          bool
+	MaxJobs        int
+	Cores          int
+	LogFormat      string
+	Includes       []string
+	Options        map[string]string
+
+	RecreateLockFile bool
+	NoUpdateLockFile bool
+	NoWriteLockFile  bool
+	NoUseRegistries  bool
+	CommitLockFile   bool
+	UpdateInputs     []string
+	OverrideInputs   map[string]string
 }
 
 type OptionOpts struct {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -95,3 +95,11 @@ func (v *VMBuild) BuildAttr() string {
 		return "vm"
 	}
 }
+
+type ImageBuild struct {
+	Variant string
+}
+
+func (i *ImageBuild) BuildAttr() string {
+	return fmt.Sprintf("images.%s", i.Variant)
+}

--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -105,7 +105,7 @@ func (f *FlakeRef) EvalAttribute(attr string) (*string, error) {
 	return &value, nil
 }
 
-func (f *FlakeRef) buildLocalSystem(s *system.LocalSystem, buildType SystemBuildType, opts *SystemBuildOptions) (string, error) {
+func (f *FlakeRef) buildLocalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemBuildOptions) (string, error) {
 	nixCommand := "nix"
 	if opts.UseNom {
 		nixCommand = "nom"
@@ -157,7 +157,7 @@ func (f *FlakeRef) buildLocalSystem(s *system.LocalSystem, buildType SystemBuild
 	return strings.Trim(stdout.String(), "\n "), err
 }
 
-func (f *FlakeRef) buildRemoteSystem(s *system.SSHSystem, buildType SystemBuildType, opts *SystemBuildOptions) (string, error) {
+func (f *FlakeRef) buildRemoteSystem(s *system.SSHSystem, buildType BuildType, opts *SystemBuildOptions) (string, error) {
 	evalArgs := nixopts.NixOptionsToArgsListByCategory(opts.CmdFlags, opts.NixOpts, "lock")
 	buildArgs := nixopts.NixOptionsToArgsListByCategory(opts.CmdFlags, opts.NixOpts, "build")
 
@@ -223,7 +223,7 @@ func (f *FlakeRef) buildRemoteSystem(s *system.SSHSystem, buildType SystemBuildT
 	return strings.TrimSpace(realisedPathBuf.String()), err
 }
 
-func (f *FlakeRef) BuildSystem(buildType SystemBuildType, opts *SystemBuildOptions) (string, error) {
+func (f *FlakeRef) BuildSystem(buildType BuildType, opts *SystemBuildOptions) (string, error) {
 	if f.Builder == nil {
 		panic("FlakeRef.Builder is nil")
 	}


### PR DESCRIPTION
## Description

`nixos-rebuild.sh` supports building images for various platforms, like standalone installer ISOs, Proxmox images, EC2 images, and the like through its `config.system.build.images` attribute.

This PR adds support for building those images, similar to the way that it can already build NixOS VMs.

Closes #113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --image / -i to build disk-image variants and list available variants when none or invalid.
  * Build output now shows the produced image path or VM/script location with clearer messages.

* **Bug Fixes**
  * Validate requested images before building; requesting "_list" prints available images and exits.
  * Restrict root re-execution to local system activation scenarios.

* **Refactor**
  * Reorganized Nix/build option handling and build-path selection (no user-facing behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->