### PR TITLE
fix(install): resolve longstanding bugs with installation process

### DIFF
--- a/cmd/enter/run.go
+++ b/cmd/enter/run.go
@@ -60,6 +60,13 @@ func enterMain(cmd *cobra.Command, opts *cmdOpts.EnterOpts) error {
 		return err
 	}
 
+	log.Infof("bind-mounting /sys to %v", opts.RootLocation)
+	err = bindMountDirectory(opts.RootLocation, "/sys")
+	if err != nil {
+		log.Errorf("failed to bind-mount /sys: %v", err)
+		return err
+	}
+
 	log.Infof("bind-mounting /proc to %v", opts.RootLocation)
 	err = bindMountDirectory(opts.RootLocation, "/proc")
 	if err != nil {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -195,6 +195,12 @@ func copyChannel(cobraCmd *cobra.Command, s system.CommandRunner, mountpoint str
 	log := s.Logger()
 
 	mountpointChannelDir := filepath.Join(mountpoint, constants.NixChannelDirectory)
+	rootProfileDir := filepath.Dir(mountpointChannelDir)
+
+	err := os.MkdirAll(rootProfileDir, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %s", rootProfileDir, err)
+	}
 
 	channelPath := channelDirectory
 	if channelPath == "" {
@@ -222,7 +228,7 @@ func copyChannel(cobraCmd *cobra.Command, s system.CommandRunner, mountpoint str
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	log.CmdArray(argv)
 
-	_, err := s.Run(cmd)
+	_, err = s.Run(cmd)
 	if err != nil {
 		log.Errorf("failed to copy channel: %v", err)
 		return err


### PR DESCRIPTION
There were three bugs with the `nixos install` command:

- The `--system` command-line flag was not being used at _all_ (probably a bug from the Zig -> Go port), and was missing some extra validation.
- The `$mountpoint/nix/var/nix/profiles/per-user/root/channels` directory was getting created directly, when it was supposed to be a symlink created by Nix. This caused Nix to fail when copying the initial channel. This creates only the `per-user/root` directory for Nix to place the channel links in.
- The `nixos enter` command did not bind-mount `/sys`, which lead to failures with installing GRUB and `systemd-boot` on UEFI systems since it didn't know where the EFI variables were.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wording in system setup instructions.

* **Improvements**
  * Mounts system metadata (/sys) during startup with logging and error handling for more reliable initialization.
  * Strengthened validation for installation options (mutual-exclusion and absolute-path/existence checks).
  * Ensure channel destination directories are created before copying.
  * Skip rebuilding when a pre-built system closure is provided; improved build flow and error reporting.
  * Clarified and corrected the root-password hint messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->