### PR TITLE
feat: specify parameters for file and attribute for legacy-style CLIs

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -275,7 +275,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	case *configuration.FlakeRef:
 		configDirname = c.URI
 	case *configuration.LegacyConfiguration:
-		configDirname = c.ConfigDirname
+		configDirname = c.Dirname()
 	}
 
 	configIsDirectory := true

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -285,11 +285,17 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			log.Error(err)
 			return err
 		}
+
 		nixConfig = &configuration.LegacyConfiguration{
 			Includes:        opts.NixOptions.Includes,
 			ConfigPath:      configPath,
 			Attribute:       opts.Attr,
 			UseExplicitPath: true,
+		}
+
+		log.Debugf("found configuration at %s", configPath)
+		if opts.Attr != "" {
+			log.Debugf("using attribute '%s'", opts.Attr)
 		}
 	} else {
 		c, err := configuration.FindConfiguration(log, cfg, opts.NixOptions.Includes)

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -102,11 +102,12 @@ func optionMain(cmd *cobra.Command, opts *cmdOpts.OptionOpts) error {
 
 	var nixosConfig configuration.Configuration
 	if opts.FlakeRef != "" {
-		nixosConfig = configuration.FlakeRefFromString(opts.FlakeRef)
-		if err := nixosConfig.(*configuration.FlakeRef).InferSystemFromHostnameIfNeeded(); err != nil {
+		ref := configuration.FlakeRefFromString(opts.FlakeRef)
+		if err := ref.InferSystemFromHostnameIfNeeded(); err != nil {
 			log.Errorf("failed to infer hostname: %v", err)
 			return err
 		}
+		nixosConfig = ref
 	} else {
 		c, err := configuration.FindConfiguration(log, cfg, opts.NixPathIncludes)
 		if err != nil {

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -6,7 +6,13 @@ nixos apply - build and/or activate a NixOS configuration
 
 # SYNOPSIS
 
+Flake-enabled CLIs:
+
 *nixos apply* [FLAKE-REF] [options]
+
+Legacy CLIs:
+
+*nixos apply* [FILE] [ATTR] [options]
 
 # DESCRIPTION
 
@@ -37,6 +43,16 @@ _`nixos-rebuild switch`_, without interactive confirmation
 _nixos-rebuild switch_, on an arbitrary flake ref (for flake-enabled CLIs only)
 
 	*nixos apply "github:water-sucks/nixed#CharlesWoodson"*
+
+_nixos-rebuild switch_, on an arbitrary Nix file containing a configuration (for
+legacy CLIs only):
+
+	*nixos apply /home/user/.nixconfig/config.nix*
+
+_nixos-rebuild switch_, on an arbitrary Nix file containing multiple
+configurations in an attribute set (for legacy CLIs only):
+
+	*nixos apply /home/user/.nixconfig/machines.nix SebastianJanikowski*
 
 _nixos-rebuild test_
 
@@ -81,6 +97,22 @@ global *--config* flag as such:
 	See *nixos-config-env(5)* for the proper flake ref format.
 
 	Default: *$NIXOS_CONFIG*
+
+*FILE*
+	Specify an explicit path to a Nix file containing a NixOS configuration.
+
+	This argument is useful for building a NixOS system from a Nix file that is
+	not a flake or a NixOS configuration module.
+
+	If not specified, then the value in the environment variable _$NIXOS_CONFIG_
+	or the value of the _nixos-config_ entry in _$NIX_PATH_ will be used.
+
+*ATTR*
+	Use the specified attribute path inside of *FILE* as the NixOS system to
+	build.
+
+	If *ATTR* is not specified, then the top-level attribute of *FILE* will be
+	used.
 
 # OPTIONS
 

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -101,6 +101,8 @@ global *--config* flag as such:
 *FILE*
 	Specify an explicit path to a Nix file containing a NixOS configuration.
 
+	Only available on legacy CLIs.
+
 	This argument is useful for building a NixOS system from a Nix file that is
 	not a flake or a NixOS configuration module.
 
@@ -110,6 +112,8 @@ global *--config* flag as such:
 *ATTR*
 	Use the specified attribute path inside of *FILE* as the NixOS system to
 	build.
+
+	Only available on legacy CLIs.
 
 	If *ATTR* is not specified, then the top-level attribute of *FILE* will be
 	used.

--- a/doc/man/nixos-cli-install.1.scd
+++ b/doc/man/nixos-cli-install.1.scd
@@ -6,7 +6,13 @@ nixos install - install a NixOS system from a provided configuration
 
 # SYNOPSIS
 
+Flake-enabled CLIs:
+
 *nixos install* [FLAKE-REF] [options]
+
+Legacy CLIs:
+
+*nixos install* [FILE] [ATTR] [options]
 
 # DESCRIPTION
 
@@ -20,12 +26,13 @@ nixos install - install a NixOS system from a provided configuration
 The installed configuration will depend on if the CLI is flake-enabled or not.
 
 If the CLI is flake-enabled:
-	- The *[FLAKE-REF]* argument is _required_, and must point to a valid
+	- The *FLAKE-REF* argument is _required_, and must point to a valid
 	  flake reference with a NixOS configuration.
 Otherwise:
 	- The *$NIXOS_CONFIG* variable must point to a valid NixOS configuration
 	  module or a directory containing a _default.nix_ with the same.
 	- OR the target root must have a file at _/etc/nixos/configuration.nix_
+	- OR *FILE* + *ATTR* should be passed.
 
 The installation will take place relative to a specified root directory
 (defaults to `/mnt`). Mountpoints and all other filesystems must be mounted
@@ -100,6 +107,26 @@ is also possible, assuming a successful installation.
 
 	There is no fallback, so if this argument is not provided on a flake-enabled
 	CLI, the program will fail.
+
+*FILE*
+	Specify an explicit path to a Nix file containing a NixOS configuration.
+
+	Only available on legacy CLIs.
+
+	This argument is useful for building a NixOS system from a Nix file that is
+	not a flake or a NixOS configuration module.
+
+	If not specified, then the value in the environment variable _$NIXOS_CONFIG_
+	or the value of the _nixos-config_ entry in _$NIX_PATH_ will be used.
+
+*ATTR*
+	Use the specified attribute path inside of *FILE* as the NixOS system to
+	build.
+
+	Only available on legacy CLIs.
+
+	If *ATTR* is not specified, then the top-level attribute of *FILE* will be
+	used.
 
 # OPTIONS
 

--- a/doc/man/nixos-cli-option.1.scd
+++ b/doc/man/nixos-cli-option.1.scd
@@ -45,8 +45,26 @@ Find an option in a different flake ref (assume a flake-enabled CLI):
 
 # OPTIONS
 
-*-h*, *--help*
-	Show the help message for this command.
+*--attr* <PATH>
+	Use the specified attribute path inside of *--file* as the NixOS system to
+	evaluate options from.
+
+	Only available on legacy CLIs.
+
+	If *--attr* is not specified, then the top-level attribute of what is passed
+	to *--file* will be used.
+
+*--file* <PATH>
+	Specify an explicit *PATH* to a Nix file containing a NixOS configuration
+	to evaluate options from.
+
+	Only available on legacy CLIs.
+
+	This argument is useful for getting options for a NixOS system from a Nix
+	file that is not a flake or a NixOS configuration module.
+
+	If not specified, then the value in the environment variable _$NIXOS_CONFIG_
+	or the value of the _nixos-config_ entry in _$NIX_PATH_ will be used.
 
 *-f*, *--flake* <REF>
 	Specify an explicit flake *REF* to evaluate options from. Only available
@@ -68,13 +86,6 @@ Find an option in a different flake ref (assume a flake-enabled CLI):
 	Errors will have an "error" key along with "similar_options" with the
 	list of at max 10 items that have been matched.
 
-*-s*, *--min-score* <SCORE>
-	Minimum fuzzy match *SCORE* for filtering results. The bigger the number,
-	the less search results will appear. However, the results will be more
-	relevant as they appear if the score is higher.
-
-	Default: *1*
-
 *--no-cache*
 	Disable usage of the prebuilt options cache.
 
@@ -86,10 +97,20 @@ Find an option in a different flake ref (assume a flake-enabled CLI):
 	Do not start the interactive search environment. This option is implied
 	when *--json* or *--value-only* modes are in use.
 
+*-s*, *--min-score* <SCORE>
+	Minimum fuzzy match *SCORE* for filtering results. The bigger the number,
+	the less search results will appear. However, the results will be more
+	relevant as they appear if the score is higher.
+
+	Default: *1*
+
 *-v*, *--value-only*
 	Print only the current value of the selected option.
 
 	Useful for scripts where the option name is needed.
+
+*-h*, *--help*
+	Show the help message for this command.
 
 # ARGUMENTS
 

--- a/doc/man/nixos-cli-repl.1.scd
+++ b/doc/man/nixos-cli-repl.1.scd
@@ -22,7 +22,8 @@ contain a valid flake ref.
 
 If not, the environment variable *$NIXOS_CONFIG* will be
 used, or the configuration can be passed through setting the *$NIX_PATH*'s
-_nixos-config_ attribute properly through *-I* or elsewhere.
+_nixos-config_ attribute properly through *-I* or elsewhere, or passed using
+*FILE* and *ATTR* directly if already instantiated there.
 
 # OPTIONS
 
@@ -39,10 +40,28 @@ _nixos-config_ attribute properly through *-I* or elsewhere.
 # ARGUMENTS
 
 *FLAKE-REF*  
-	Optional flake reference to load attributes from. If the CLI is not
-	flake-enabled, this argument is ignored.
+	Optional flake reference to load attributes from. Only available on
+	flake-enabled CLIs.
 
 	Default: *$NIXOS_CONFIG*
+
+*FILE*
+	Specify an explicit path to a Nix file containing a NixOS configuration to
+	load into the REPL.
+
+	Only available on legacy CLIs.
+
+	If not specified, then the value in the environment variable _$NIXOS_CONFIG_
+	or the value of the _nixos-config_ entry in _$NIX_PATH_ will be used.
+
+*ATTR*
+	Use the specified attribute path inside of *FILE* as the NixOS system to
+	use for the REPL.
+
+	Only available on legacy CLIs.
+
+	If *ATTR* is not specified, then the top-level attribute of *FILE* will be
+	used.
 
 # SEE ALSO
 

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -202,6 +202,8 @@ type OptionOpts struct {
 	MinScore         int64
 	OptionInput      string
 	FlakeRef         string
+	File             string
+	Attr             string
 }
 
 type ReplOpts struct {

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -159,6 +159,8 @@ type InstallOpts struct {
 	SystemClosure  string
 	Verbose        bool
 	FlakeRef       *configuration.FlakeRef
+	File           string
+	Attr           string
 
 	NixOptions InstallNixOpts
 }

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -21,15 +21,17 @@ type AliasesOpts struct {
 }
 
 type ApplyOpts struct {
+	File                  string
+	Attr                  string
 	AlwaysConfirm         bool
 	BuildHost             string
+	BuildImage            string
 	BuildVM               bool
 	BuildVMWithBootloader bool
 	Dry                   bool
 	FlakeRef              string
 	GenerationTag         string
 	InstallBootloader     bool
-	BuildImage            string
 	NoActivate            bool
 	NoBoot                bool
 	OutputPath            string

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -207,4 +207,6 @@ type OptionOpts struct {
 type ReplOpts struct {
 	NixPathIncludes []string
 	FlakeRef        string
+	File            string
+	Attr            string
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -77,11 +77,7 @@ type SystemBuild struct {
 }
 
 func (s *SystemBuild) BuildAttr() string {
-	if build.Flake() {
-		return "toplevel"
-	} else {
-		return "system"
-	}
+	return "toplevel"
 }
 
 type VMBuild struct {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -62,7 +62,7 @@ func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []str
 			return nil, err
 		}
 
-		log.Debugf("found legacy configuration at %s", c.ConfigDirname)
+		log.Debugf("found legacy configuration at %s", c.ConfigPath)
 
 		return c, nil
 	}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -37,7 +37,7 @@ type AttributeEvaluationError struct {
 }
 
 func (e *AttributeEvaluationError) Error() string {
-	return fmt.Sprintf("failed to evaluate attribute %s", e.Attribute)
+	return fmt.Sprintf("failed to evaluate attribute %s, trace:\n%s", e.Attribute, e.EvaluationOutput)
 }
 
 func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []string) (Configuration, error) {

--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -77,6 +77,10 @@ func (f *FlakeRef) InferSystemFromHostnameIfNeeded() error {
 	return nil
 }
 
+func (f *FlakeRef) String() string {
+	return fmt.Sprintf("%s#%s", f.URI, f.System)
+}
+
 func (f *FlakeRef) SetBuilder(builder system.CommandRunner) {
 	f.Builder = builder
 }

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -87,8 +87,20 @@ func (l *LegacyConfiguration) SetBuilder(builder system.CommandRunner) {
 }
 
 func (l *LegacyConfiguration) EvalAttribute(attr string) (*string, error) {
-	configAttr := fmt.Sprintf("config.%s", attr)
-	argv := []string{"nix-instantiate", "--eval", "<nixpkgs/nixos>", "-A", configAttr}
+	var argv []string
+	if l.UseExplicitPath {
+		var fullAttrPath strings.Builder
+		if l.Attribute != "" {
+			fullAttrPath.WriteString(l.Attribute)
+			fullAttrPath.WriteString(".")
+		}
+		fullAttrPath.WriteString("config.")
+		fullAttrPath.WriteString(attr)
+
+		argv = []string{"nix-instantiate", "--eval", l.ConfigPath, "-A", fullAttrPath.String()}
+	} else {
+		argv = []string{"nix-instantiate", "--eval", "<nixpkgs/nixos>", "-A", fmt.Sprintf("config.%s", attr)}
+	}
 
 	for _, v := range l.Includes {
 		argv = append(argv, "-I", v)

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -111,16 +111,7 @@ func (l *LegacyConfiguration) buildLocalSystem(s *system.LocalSystem, buildType 
 		nixCommand = "nom-build"
 	}
 
-	argv := []string{nixCommand, "<nixpkgs/nixos>", "-A"}
-	switch buildType.(type) {
-	case *ImageBuild:
-		// The build attribute for image builds is not in the
-		// usual toplevel of the <nixpkgs/nixos> attribute.
-		// Handle this case specially.
-		argv = append(argv, fmt.Sprintf("config.system.build.%s", buildType.BuildAttr()))
-	default:
-		argv = append(argv, buildType.BuildAttr())
-	}
+	argv := []string{nixCommand, "<nixpkgs/nixos>", "-A", fmt.Sprintf("config.system.build.%s", buildType.BuildAttr())}
 
 	// Mimic `nixos-rebuild` behavior of using -k option
 	// for all commands except for `switch` and `boot`
@@ -176,16 +167,7 @@ func (l *LegacyConfiguration) buildRemoteSystem(s *system.SSHSystem, buildType B
 
 	// 1. Determine the drv path.
 	// Equivalent of `nix-instantiate -A "${attr}" ${extraBuildFlags[@]}`
-	instantiateArgv := []string{"nix-instantiate", "<nixpkgs/nixos>", "-A"}
-	switch buildType.(type) {
-	case *ImageBuild:
-		// The build attribute for image builds is not in the
-		// usual toplevel of the <nixpkgs/nixos> attribute.
-		// Handle this case specially.
-		instantiateArgv = append(instantiateArgv, fmt.Sprintf("config.system.build.%s", buildType.BuildAttr()))
-	default:
-		instantiateArgv = append(instantiateArgv, buildType.BuildAttr())
-	}
+	instantiateArgv := []string{"nix-instantiate", "<nixpkgs/nixos>", "-A", fmt.Sprintf("config.system.build.%s", buildType.BuildAttr())}
 	instantiateArgv = append(instantiateArgv, extraBuildFlags...)
 
 	var drvPathBuf bytes.Buffer


### PR DESCRIPTION
For already-instantiated configurations, it can be hard to retrieve their values or build with them purely using Nix include arguments (aka `-I`) or by setting `$NIXOS_CONFIG`. 

This gives users the explicit ability to pass already-instantiated user configurations as positional arguments, similar to flake refs, but for legacy-style configurations only, for the following commands:

- `nixos apply`
- `nixos install`
- `nixos option`
- `nixos repl`

Closes #120.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply, Install, Option, and REPL commands accept optional FILE and ATTR arguments to target legacy (non-flake) configurations.
  * Commands can load explicit file paths and attributes and infer system names when using flake refs.

* **Improvements**
  * More robust resolution of nix configuration paths and clearer debug logging.

* **Documentation**
  * Manual pages updated with FILE/ATTR usage, examples, and option descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->