### PR TITLE
fix(nix): rename pkgs.system -> pkgs.stdenv.hostPlatform.system

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
 {pkgs ? import <nixpkgs> {}}: let
   flakeSelf = import ./flake-compat.nix;
+  inherit (pkgs.stdenv.hostPlatform) system;
 in {
-  inherit (flakeSelf.packages.${pkgs.system}) nixos nixosLegacy;
+  inherit (flakeSelf.packages.${system}) nixos nixosLegacy;
 
   # Do not use lib.importApply here for better error tracking, since
   # it causes an infinite recursion for a currently unknown reason.

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,12 @@
       pkgs = pkgsFor system;
       inherit (pkgs) callPackage;
     in {
-      default = self.packages.${pkgs.system}.nixos;
+      default = self.packages.${system}.nixos;
 
       nixos = callPackage ./package.nix {
         revision = self.rev or self.dirtyRev or "unknown";
       };
-      nixosLegacy = self.packages.${pkgs.system}.nixos.override {flake = false;};
+      nixosLegacy = self.packages.${system}.nixos.override {flake = false;};
     });
 
     devShells = eachSystem (system: let

--- a/module.nix
+++ b/module.nix
@@ -11,6 +11,8 @@
   cfg = config.services.nixos-cli;
   nixosCfg = config.system.nixos;
 
+  inherit (pkgs.stdenv.hostPlatform) system;
+
   inherit (lib) types;
 
   tomlFormat = pkgs.formats.toml {};
@@ -22,8 +24,8 @@ in {
       type = types.package;
       default =
         if useFlakePkg
-        then self.packages.${pkgs.system}.nixos
-        else self.packages.${pkgs.system}.nixosLegacy;
+        then self.packages.${system}.nixos
+        else self.packages.${system}.nixosLegacy;
       description = "Package to use for nixos-cli";
     };
 


### PR DESCRIPTION
## Description

This was a recent change in upstream `nixpkgs`, to deprecate the shorthand for `pkgs.stdenv.hostPlatform.system`. This PR updates any usage of the old attribute to the new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent system platform detection across build configurations, ensuring accurate package resolution for your system architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->