### PR TITLE
fix(init): resolve filesystem attribute generation bugs

### DIFF
--- a/cmd/init/generate.go
+++ b/cmd/init/generate.go
@@ -315,7 +315,7 @@ func nixStringList(s []string) string {
 const (
 	fileSystemEntryKeyTemplate = `  fileSystems."%s" = {` + "\n"
 	fileSystemDeviceTemplate   = `    device = "%s";` + "\n"
-	fileSystemTypeTemplate     = `    type = "%s";` + "\n"
+	fileSystemTypeTemplate     = `    fsType = "%s";` + "\n"
 	fileSystemOptionTemplate   = `    options = [%s];` + "\n"
 
 	fileSystemLuksTemplate = `  boot.initrd.luks.devices."%s".device = "%s";` + "\n\n"

--- a/cmd/init/generate.go
+++ b/cmd/init/generate.go
@@ -333,7 +333,7 @@ func generateFilesystemAttrset(filesystem *Filesystem) string {
 		_, _ = fsStr.WriteString(optionStr)
 	}
 
-	fsStr.WriteString("  }\n")
+	fsStr.WriteString("  };\n")
 
 	luks := filesystem.LUKSInformation
 	if luks != nil {


### PR DESCRIPTION
## Description

There were two bugs with generation of filesystem attributes:

- A missing semicolon from the end of the attribute set
- The filesystem type is specified as an attribute called `fsType`, not `type`.

Can't believe I didn't find these before, but oh well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Nix configuration generation for filesystem attribute definitions and syntax formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->