### PR TITLE
feat(apply): magic rollback

### DIFF
--- a/cmd/activate/activate.go
+++ b/cmd/activate/activate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/activation"
 	cmdOpts "github.com/nix-community/nixos-cli/internal/cmd/opts"
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
+	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,17 @@ func ActivateCommand() *cobra.Command {
 			}
 
 			return results, cobra.ShellCompDirectiveNoFileComp
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			log := logger.FromContext(ctx)
+
+			if opts.Verbose {
+				log.SetLogLevel(logger.LogLevelDebug)
+			}
+
+			ctx = logger.WithLogger(ctx, log)
+			cmd.SetContext(ctx)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdUtils.CommandErrorHandler(activateMain(cmd, &opts))

--- a/cmd/activate/run.go
+++ b/cmd/activate/run.go
@@ -101,13 +101,13 @@ func getRequiredVars() (*RequiredVars, error) {
 }
 
 func execInSwitchContext(
-	s system.CommandRunner,
+	s system.System,
 	log logger.Logger,
 	action activation.SwitchToConfigurationAction,
 	specialisation string,
 ) error {
 	if specialisation != "" {
-		specialisations, err := generation.CollectSpecialisations(constants.CurrentSystem)
+		specialisations, err := generation.CollectSpecialisations(s, constants.CurrentSystem)
 		if err != nil {
 			log.Warnf("unable to access specialisations: %v", err)
 		}

--- a/cmd/activate/run.go
+++ b/cmd/activate/run.go
@@ -32,8 +32,6 @@ import (
 )
 
 const (
-	ACTIVATION_LOCKFILE = "/run/nixos/switch-to-configuration.lock"
-
 	DRY_RESTART_BY_ACTIVATION_LIST_FILE = "/run/nixos/dry-activation-restart-list"
 	DRY_RELOAD_BY_ACTIVATION_LIST_FILE  = "/run/nixos/dry-activation-reload-list"
 	RELOAD_BY_ACTIVATION_LIST_FILE      = "/run/nixos/activation-reload-list"
@@ -312,6 +310,28 @@ func waitForSystemdToSettle(systemd *systemdDbus.Conn, idleTimeout time.Duration
 	}
 }
 
+// Acquire a process-level lock.
+//
+// Returns a function that releases the lock, or an error if
+// something went wrong when locking the file.
+func acquireLock(log logger.Logger) (func(), error) {
+	lockfile, err := os.OpenFile(activation.ACTIVATION_LOCKFILE, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		log.Errorf("failed to create activation lockfile %s: %s", activation.ACTIVATION_LOCKFILE, err)
+		return nil, err
+	}
+
+	if err = unix.Flock(int(lockfile.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		log.Errorf("failed to lock %s; is another activation process running?", activation.ACTIVATION_LOCKFILE)
+		lockfile.Close()
+		return nil, err
+	}
+
+	return func() {
+		_ = lockfile.Close()
+	}, nil
+}
+
 func activateMain(cmd *cobra.Command, opts *cmdOpts.ActivateOpts) error {
 	log := logger.FromContext(cmd.Context())
 	s := system.NewLocalSystem(log)
@@ -363,25 +383,16 @@ func activateMain(cmd *cobra.Command, opts *cmdOpts.ActivateOpts) error {
 		return err
 	}
 
-	err = os.MkdirAll("/run/nixos", 0o755)
-	if err != nil {
-		log.Errorf("failed to create /run/nixos: %s", err)
+	if err = activation.EnsureActivationDirectoryExists(); err != nil {
+		log.Error(err)
 		return err
 	}
 
-	lockfile, err := os.OpenFile(ACTIVATION_LOCKFILE, os.O_CREATE|os.O_RDWR, 0o600)
+	releaseLock, err := acquireLock(log)
 	if err != nil {
-		log.Errorf("failed to create activation lockfile %s: %s", ACTIVATION_LOCKFILE, err)
 		return err
 	}
-	defer func() { _ = lockfile.Close() }()
-
-	if err = unix.Flock(int(lockfile.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
-		log.Errorf("failed to lock %s", ACTIVATION_LOCKFILE)
-		log.Info("is another activation process running?")
-		return err
-	}
-	defer func() { _ = unix.Flock(int(lockfile.Fd()), unix.LOCK_UN) }()
+	defer releaseLock()
 
 	var syslogLogger *logger.SyslogLogger
 	if syslogLogger, err = logger.NewSyslogLogger("nixos-cli-activate"); err == nil {

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -680,8 +680,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	previousGenNumber, err := activation.GetCurrentGenerationNumber(targetHost, opts.ProfileName)
 	if err != nil {
-		log.Errorf("%v", err)
-		return err
+		log.Warnf("%v", err)
 	}
 
 	activationMissingRoot := !effectiveRoot && !opts.LocalRoot && !targetHost.IsRemote()
@@ -689,7 +688,6 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	if rootElevator != nil && activationUseRoot {
 		if rootElevator.PasswordProvider != nil {
-			log.Infof("please enter password for %s", rootElevator.Command)
 			if err = rootElevator.PromptIfNecessary(stopCtx); err != nil {
 				log.Error(err)
 				return err
@@ -715,8 +713,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		var prevLink string
 		prevLink, err = targetHost.FS().ReadLink(activeProfileLink)
 		if err != nil {
-			log.Errorf("%v", err)
-			return err
+			log.Warnf("failed to readlink %s: %v", activeProfileLink, err)
 		}
 
 		if activationMissingRoot {
@@ -741,12 +738,13 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		var afterLink string
 		afterLink, err = targetHost.FS().ReadLink(activeProfileLink)
 		if err != nil {
-			log.Errorf("%v", err)
-			return err
+			log.Warnf("failed to readlink %s: %v", activeProfileLink, err)
 		}
 
-		if prevLink != afterLink {
-			newGenerationCreated = true
+		if prevLink != "" && afterLink != "" {
+			if prevLink != afterLink {
+				newGenerationCreated = true
+			}
 		}
 	}
 
@@ -759,14 +757,28 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 		log.Step("Rolling back system profile...")
 
-		if rbErr := activation.SetNixProfileGeneration(
-			targetHost,
-			opts.ProfileName,
-			previousGenNumber, &activation.SetNixProfileGenerationOptions{
-				RootElevator:   rootElevator,
-				UseRootCommand: activationUseRoot,
-			},
-		); rbErr != nil {
+		var rbErr error
+		if previousGenNumber > 0 {
+			rbErr = activation.SetNixProfileGeneration(
+				targetHost,
+				opts.ProfileName,
+				previousGenNumber, &activation.SetNixProfileGenerationOptions{
+					RootElevator:   rootElevator,
+					UseRootCommand: activationUseRoot,
+				},
+			)
+		} else {
+			rbErr = activation.RollbackNixProfile(
+				targetHost,
+				opts.ProfileName,
+				&activation.RollbackNixProfileOptions{
+					RootElevator:   rootElevator,
+					UseRootCommand: activationUseRoot,
+				},
+			)
+		}
+
+		if rbErr != nil {
 			log.Errorf("failed to rollback system profile: %v", rbErr)
 			log.Info("make sure to rollback the system manually before deleting anything!")
 		}

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -34,7 +34,9 @@ import (
 )
 
 func ApplyCommand(cfg *settings.Settings) *cobra.Command {
-	opts := cmdOpts.ApplyOpts{}
+	opts := cmdOpts.ApplyOpts{
+		RollbackTimeout: systemdUtils.SystemdDuration(30 * time.Second),
+	}
 
 	var usage string
 	if build.Flake() {
@@ -109,11 +111,10 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 				}
 			}
 
-			// Make sure rollback-timeout is a valid systemd.time(7) string
-			if timeout, err := systemdUtils.DurationFromTimeSpan(opts.RollbackTimeout); err != nil {
-				return fmt.Errorf("invalid value for --rollback-timeout: %v", err.Error())
-			} else if timeout < 1*time.Second {
-				return errors.New("--rollback-timeout must be at least 1 second")
+			if cmd.Flags().Changed("rollback-timeout") {
+				if opts.RollbackTimeout.Duration() < 1*time.Second {
+					return errors.New("--rollback-timeout must be at least 1 second")
+				}
 			}
 
 			// Set a special hidden _list value for this
@@ -162,7 +163,7 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 	cmd.Flags().StringVar(&opts.BuildHost, "build-host", "", "Use specified `user@host:port` to perform build")
 	cmd.Flags().StringVar(&opts.TargetHost, "target-host", "", "Deploy to a remote machine at `user@host:port`")
 	cmd.Flags().StringVar(&opts.StorePath, "store-path", "", "Use a pre-built NixOS system store `path` instead of building")
-	cmd.Flags().StringVar(&opts.RollbackTimeout, "rollback-timeout", "30s", "Time `period` to wait for acknowledgement signal before automatic rollback")
+	cmd.Flags().Var(&opts.RollbackTimeout, "rollback-timeout", "Time `period` to wait for acknowledgement signal before automatic rollback")
 	cmd.Flags().BoolVar(&opts.NoRollback, "no-rollback", false, "Do not attempt rollback after a switch failure")
 
 	opts.NixOptions.Quiet.Bind(&cmd)
@@ -199,6 +200,8 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 		cmd.Flags().BoolVar(&opts.UpgradeChannels, "upgrade", false, "Upgrade the root user`s 'nixos' channel")
 		cmd.Flags().BoolVar(&opts.UpgradeAllChannels, "upgrade-all", false, "Upgrade all the root user's channels")
 	}
+
+	cmdUtils.RemoveDefaultValueDesc(&cmd, "rollback-timeout")
 
 	_ = cmd.RegisterFlagCompletionFunc("profile-name", generation.CompleteProfileFlag)
 	_ = cmd.RegisterFlagCompletionFunc("specialisation", generation.CompleteSpecialisationFlagFromConfig(opts.FlakeRef, opts.NixOptions.Include))
@@ -796,8 +799,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	useActivationSupervisor := shouldUseActivationSupervisor(cfg, targetHost, stcAction) && !opts.NoRollback
 
 	if useActivationSupervisor {
-		ackTimeout, _ := systemdUtils.DurationFromTimeSpan(opts.RollbackTimeout)
-		ackTimeout = ackTimeout / time.Second
+		ackTimeout := opts.RollbackTimeout.Duration() / time.Second
 
 		// Let the supervisor handle the rollback if it exists.
 		err = activation.RunActivationSupervisor(targetHost, resultLocation, stcAction, &activation.RunActivationSupervisorOptions{

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -688,8 +688,23 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	// testing generations using the --no-boot option.
 	createGeneration := !opts.Dry && !opts.NoBoot
 
+	// New generations may not always be created, in the case of
+	// running `apply` on the same exact configuration.
+	// Track this here, and do not perform a system profile
+	// rollback if one hasn't been created.
+	newGenerationCreated := false
+
 	if createGeneration {
 		log.Step("Setting system profile...")
+
+		activeProfileLink := generation.GetProfileDirectoryFromName(opts.ProfileName)
+
+		var prevLink string
+		prevLink, err = targetHost.FS().ReadLink(activeProfileLink)
+		if err != nil {
+			log.Errorf("%v", err)
+			return err
+		}
 
 		if activationMissingRoot {
 			err := errRequiresLocalRoot{Action: "setting a system profile locally"}
@@ -709,6 +724,17 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			log.Errorf("failed to set system profile: %v", err)
 			return err
 		}
+
+		var afterLink string
+		afterLink, err = targetHost.FS().ReadLink(activeProfileLink)
+		if err != nil {
+			log.Errorf("%v", err)
+			return err
+		}
+
+		if prevLink != afterLink {
+			newGenerationCreated = true
+		}
 	}
 
 	// In case switch-to-configuration fails, rollback the profile.
@@ -717,7 +743,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	// fails, since the active profile will not be rolled back
 	// automatically.
 	rollbackProfile := false
-	if createGeneration {
+
+	if newGenerationCreated {
 		defer func(rollback *bool) {
 			if !*rollback {
 				return
@@ -766,16 +793,43 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		panic("unknown switch to configuration action to take, this is a bug")
 	}
 
-	err = activation.SwitchToConfiguration(targetHost, resultLocation, stcAction, &activation.SwitchToConfigurationOptions{
-		InstallBootloader: opts.InstallBootloader,
-		Specialisation:    specialisation,
-		UseRootCommand:    activationUseRoot,
-		RootElevator:      rootElevator,
-	})
-	if err != nil {
-		rollbackProfile = true
-		log.Errorf("failed to switch to configuration: %v", err)
-		return err
+	useActivationSupervisor := shouldUseActivationSupervisor(cfg, targetHost, stcAction)
+
+	if useActivationSupervisor {
+		// Let the supervisor handle the rollback if it exists.
+		rollbackProfile = false
+		err = activation.RunActivationSupervisor(targetHost, resultLocation, stcAction, &activation.RunActivationSupervisorOptions{
+			ProfileName:       opts.ProfileName,
+			InstallBootloader: opts.InstallBootloader,
+			Specialisation:    specialisation,
+			UseRootCommand:    activationUseRoot,
+			RootElevator:      rootElevator,
+
+			// TODO: figure out previous specialisation, set it here
+			// so that we can rollback directly to a given specialisation
+			// by setting it in these options.
+
+			// Only rollback the system profile if a new generation was created.
+			RollbackProfileOnFailure: newGenerationCreated,
+		})
+		if err != nil {
+			log.Errorf("%v", err)
+			return err
+		}
+	} else {
+		// Otherwise, just use the switch-to-configuration script directly
+		// and handle profile rollback ourselves.
+		err = activation.SwitchToConfiguration(targetHost, resultLocation, stcAction, &activation.SwitchToConfigurationOptions{
+			InstallBootloader: opts.InstallBootloader,
+			Specialisation:    specialisation,
+			UseRootCommand:    activationUseRoot,
+			RootElevator:      rootElevator,
+		})
+		if err != nil {
+			rollbackProfile = true
+			log.Errorf("failed to switch to configuration: %v", err)
+			return err
+		}
 	}
 
 	return nil
@@ -947,4 +1001,16 @@ func getImageName(
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
+}
+
+func shouldUseActivationSupervisor(cfg *settings.Settings, host system.System, action activation.SwitchToConfigurationAction) bool {
+	if !cfg.AutoRollback || !host.IsRemote() {
+		return false
+	}
+
+	isValidAction := action == activation.SwitchToConfigurationActionBoot ||
+		action == activation.SwitchToConfigurationActionSwitch ||
+		action == activation.SwitchToConfigurationActionTest
+
+	return isValidAction
 }

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -28,15 +28,12 @@ import (
 	"github.com/nix-community/nixos-cli/internal/settings"
 	sshUtils "github.com/nix-community/nixos-cli/internal/ssh"
 	"github.com/nix-community/nixos-cli/internal/system"
-	systemdUtils "github.com/nix-community/nixos-cli/internal/systemd"
 	"github.com/nix-community/nixos-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
 func ApplyCommand(cfg *settings.Settings) *cobra.Command {
-	opts := cmdOpts.ApplyOpts{
-		RollbackTimeout: systemdUtils.SystemdDuration(30 * time.Second),
-	}
+	opts := cmdOpts.ApplyOpts{}
 
 	var usage string
 	if build.Flake() {
@@ -754,7 +751,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	}
 
 	rollbackLocalProfile := func() {
-		if !cfg.AutoRollback {
+		if !cfg.Rollback.Enable {
 			log.Warnf("automatic rollback is disabled, the currently active profile may have unresolved problems")
 			log.Warnf("you are on your own!")
 			return
@@ -799,7 +796,10 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	useActivationSupervisor := shouldUseActivationSupervisor(cfg, targetHost, stcAction) && !opts.NoRollback
 
 	if useActivationSupervisor {
-		ackTimeout := opts.RollbackTimeout.Duration() / time.Second
+		ackTimeout := opts.RollbackTimeout
+		if ackTimeout == 0 {
+			ackTimeout = cfg.Rollback.Timeout
+		}
 
 		// Let the supervisor handle the rollback if it exists.
 		err = activation.RunActivationSupervisor(targetHost, resultLocation, stcAction, &activation.RunActivationSupervisorOptions{
@@ -808,7 +808,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			Specialisation:    specialisation,
 			UseRootCommand:    activationUseRoot,
 			RootElevator:      rootElevator,
-			AckTimeout:        ackTimeout,
+			AckTimeout:        ackTimeout.Duration(),
 
 			// TODO: figure out previous specialisation, set it here
 			// so that we can rollback directly to a given specialisation
@@ -1011,7 +1011,7 @@ func getImageName(
 }
 
 func shouldUseActivationSupervisor(cfg *settings.Settings, host system.System, action activation.SwitchToConfigurationAction) bool {
-	if !cfg.AutoRollback || !host.IsRemote() {
+	if !cfg.Rollback.Enable || !host.IsRemote() {
 		return false
 	}
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -10,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/nix-community/nixos-cli/internal/activation"
@@ -26,6 +28,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/settings"
 	sshUtils "github.com/nix-community/nixos-cli/internal/ssh"
 	"github.com/nix-community/nixos-cli/internal/system"
+	systemdUtils "github.com/nix-community/nixos-cli/internal/systemd"
 	"github.com/nix-community/nixos-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -106,6 +109,13 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 				}
 			}
 
+			// Make sure rollback-timeout is a valid systemd.time(7) string
+			if timeout, err := systemdUtils.DurationFromTimeSpan(opts.RollbackTimeout); err != nil {
+				return fmt.Errorf("invalid value for --rollback-timeout: %v", err.Error())
+			} else if timeout < 1*time.Second {
+				return errors.New("--rollback-timeout must be at least 1 second")
+			}
+
 			// Set a special hidden _list value for this
 			// flag in order to list available images and
 			// exit.
@@ -152,6 +162,8 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 	cmd.Flags().StringVar(&opts.BuildHost, "build-host", "", "Use specified `user@host:port` to perform build")
 	cmd.Flags().StringVar(&opts.TargetHost, "target-host", "", "Deploy to a remote machine at `user@host:port`")
 	cmd.Flags().StringVar(&opts.StorePath, "store-path", "", "Use a pre-built NixOS system store `path` instead of building")
+	cmd.Flags().StringVar(&opts.RollbackTimeout, "rollback-timeout", "30s", "Time `period` to wait for acknowledgement signal before automatic rollback")
+	cmd.Flags().BoolVar(&opts.NoRollback, "no-rollback", false, "Do not attempt rollback after a switch failure")
 
 	opts.NixOptions.Quiet.Bind(&cmd)
 	opts.NixOptions.PrintBuildLogs.Bind(&cmd)
@@ -198,6 +210,7 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("vm", "vm-with-bootloader", "image", "store-path")
 	cmd.MarkFlagsMutuallyExclusive("no-activate", "specialisation")
 	cmd.MarkFlagsMutuallyExclusive("eval-only", "store-path")
+	cmd.MarkFlagsMutuallyExclusive("no-rollback", "rollback-timeout")
 
 	helpTemplate := cmd.HelpTemplate()
 	if build.Flake() {
@@ -737,39 +750,26 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		}
 	}
 
-	// In case switch-to-configuration fails, rollback the profile.
-	// This is to prevent accidental deletion of all working
-	// generations in case the switch-to-configuration script
-	// fails, since the active profile will not be rolled back
-	// automatically.
-	rollbackProfile := false
+	rollbackLocalProfile := func() {
+		if !cfg.AutoRollback {
+			log.Warnf("automatic rollback is disabled, the currently active profile may have unresolved problems")
+			log.Warnf("you are on your own!")
+			return
+		}
 
-	if newGenerationCreated {
-		defer func(rollback *bool) {
-			if !*rollback {
-				return
-			}
+		log.Step("Rolling back system profile...")
 
-			if !cfg.AutoRollback {
-				log.Warnf("automatic rollback is disabled, the currently active profile may have unresolved problems")
-				log.Warnf("you are on your own!")
-				return
-			}
-
-			log.Step("Rolling back system profile...")
-
-			if err = activation.SetNixProfileGeneration(
-				targetHost,
-				opts.ProfileName,
-				previousGenNumber, &activation.SetNixProfileGenerationOptions{
-					UseRootCommand: activationUseRoot,
-					RootElevator:   rootElevator,
-				},
-			); err != nil {
-				log.Errorf("failed to rollback system profile: %v", err)
-				log.Info("make sure to rollback the system manually before deleting anything!")
-			}
-		}(&rollbackProfile)
+		if rbErr := activation.SetNixProfileGeneration(
+			targetHost,
+			opts.ProfileName,
+			previousGenNumber, &activation.SetNixProfileGenerationOptions{
+				RootElevator:   rootElevator,
+				UseRootCommand: activationUseRoot,
+			},
+		); rbErr != nil {
+			log.Errorf("failed to rollback system profile: %v", rbErr)
+			log.Info("make sure to rollback the system manually before deleting anything!")
+		}
 	}
 
 	log.Step("Activating...")
@@ -793,17 +793,20 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		panic("unknown switch to configuration action to take, this is a bug")
 	}
 
-	useActivationSupervisor := shouldUseActivationSupervisor(cfg, targetHost, stcAction)
+	useActivationSupervisor := shouldUseActivationSupervisor(cfg, targetHost, stcAction) && !opts.NoRollback
 
 	if useActivationSupervisor {
+		ackTimeout, _ := systemdUtils.DurationFromTimeSpan(opts.RollbackTimeout)
+		ackTimeout = ackTimeout / time.Second
+
 		// Let the supervisor handle the rollback if it exists.
-		rollbackProfile = false
 		err = activation.RunActivationSupervisor(targetHost, resultLocation, stcAction, &activation.RunActivationSupervisorOptions{
 			ProfileName:       opts.ProfileName,
 			InstallBootloader: opts.InstallBootloader,
 			Specialisation:    specialisation,
 			UseRootCommand:    activationUseRoot,
 			RootElevator:      rootElevator,
+			AckTimeout:        ackTimeout,
 
 			// TODO: figure out previous specialisation, set it here
 			// so that we can rollback directly to a given specialisation
@@ -826,8 +829,10 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			RootElevator:      rootElevator,
 		})
 		if err != nil {
-			rollbackProfile = true
 			log.Errorf("failed to switch to configuration: %v", err)
+			if !opts.NoRollback && newGenerationCreated {
+				rollbackLocalProfile()
+			}
 			return err
 		}
 	}

--- a/cmd/generation/delete/resolver.go
+++ b/cmd/generation/delete/resolver.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/nix-community/nixos-cli/internal/cmd/opts"
 	"github.com/nix-community/nixos-cli/internal/generation"
-	"github.com/nix-community/nixos-cli/internal/systemd"
 )
 
 type generationSet map[uint64]present
@@ -91,10 +90,8 @@ func resolveGenerationsToDelete(generations []generation.Generation, opts *cmdOp
 			}
 		}
 
-		if opts.OlderThan != "" {
-			// This is validated during argument parsing, so no need to check for errors.
-			olderThanTimeSpan, _ := systemdUtils.DurationFromTimeSpan(opts.OlderThan)
-			upperDateBound := time.Now().Add(-olderThanTimeSpan)
+		if opts.OlderThan > 0 {
+			upperDateBound := time.Now().Add(-opts.OlderThan.Duration())
 
 			for _, v := range generations {
 				if v.CreationDate.Before(upperDateBound) {

--- a/cmd/generation/delete/resolver_test.go
+++ b/cmd/generation/delete/resolver_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nix-community/nixos-cli/internal/cmd/opts"
 	"github.com/nix-community/nixos-cli/internal/generation"
+	systemdUtils "github.com/nix-community/nixos-cli/internal/systemd"
 )
 
 func TestResolveGenerationsToDelete(t *testing.T) {
@@ -61,7 +62,7 @@ func TestResolveGenerationsToDelete(t *testing.T) {
 		{
 			name: "Older than specified duration",
 			opts: &cmdOpts.GenerationDeleteOpts{
-				OlderThan: "24h",
+				OlderThan: systemdUtils.SystemdDuration(24 * time.Hour),
 			},
 			expect: []uint64{1, 2},
 		},

--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -162,7 +162,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 				return
 			}
 
-			if !cfg.AutoRollback {
+			if !cfg.Rollback.Enable {
 				log.Warnf("automatic rollback is disabled, the currently active profile may have unresolved problems")
 				log.Warnf("you are on your own!")
 				return

--- a/cmd/generation/shared/utils.go
+++ b/cmd/generation/shared/utils.go
@@ -3,10 +3,13 @@ package genUtils
 import (
 	"github.com/nix-community/nixos-cli/internal/generation"
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/system"
 )
 
 func LoadGenerations(log logger.Logger, profileName string, reverse bool) ([]generation.Generation, error) {
-	generations, err := generation.CollectGenerationsInProfile(log, profileName)
+	s := system.NewLocalSystem(log)
+
+	generations, err := generation.CollectGenerationsInProfile(s, log, profileName)
 	if err != nil {
 		switch v := err.(type) {
 		case *generation.GenerationReadError:

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -214,7 +214,7 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 				return
 			}
 
-			if !cfg.AutoRollback {
+			if !cfg.Rollback.Enable {
 				log.Warnf("automatic rollback is disabled, the currently active profile may have unresolved problems")
 				log.Warnf("you are on your own!")
 				return

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -61,7 +61,7 @@ func infoMain(cmd *cobra.Command, opts *cmdOpts.InfoOpts) error {
 		return err
 	}
 
-	currentGen, err := generation.GenerationFromDirectory(constants.CurrentSystem, currentGenNumber)
+	currentGen, err := generation.GenerationFromDirectory(s, constants.CurrentSystem, currentGenNumber)
 	if err != nil {
 		log.Warnf("failed to collect generations: %v", err)
 		return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -77,10 +77,6 @@ func mainCommand() (*cobra.Command, error) {
 		cfg = settings.NewSettings()
 	}
 
-	for _, err := range cfg.Validate() {
-		log.Warn(err.Error())
-	}
-
 	cmdCtx = settings.WithConfig(cmdCtx, cfg)
 
 	cmd := cobra.Command{

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -81,17 +81,6 @@ _`nix eval .#nixosConfigurations.$HOSTNAME.config.system.build.toplevel`_
 Many other behaviors for _nixos-rebuild_ are in the *nixos generation*
 command tree. See *nixos-cli-generation(1)* for details.
 
-## Rollback
-
-In rare cases, automatic rollback is performed on the system profile when
-activation fails.
-
-In order to disable this behavior for known working configurations (such as when
-reboot is required for a successful activation or daemon restart), use the
-global *--config* flag as such:
-
-	*nixos --config auto_rollback=false apply [options]*
-
 # ARGUMENTS
 
 *FLAKE-REF*
@@ -238,7 +227,9 @@ global *--config* flag as such:
 	*PERIOD* is a *systemd.time(7)*-formatted time span, such as *10s*. For more
 	information, see the *systemd.time(7)* man page.
 
-	Must be at least 1 second in length or more.
+	Must be at least 1 second in length.
+
+	Default: (specified in _rollback.timeout_, usually 30s)
 
 	This is only applicable to remote activations with magic rollback mode
 	enabled.
@@ -339,7 +330,7 @@ global *--config* flag as such:
 *-h*, *--help*
 	Show the help message for this command.
 
-# NIX OPTIONS
+## NIX OPTIONS
 
 *nixos apply* accepts some Nix options and passes them through to their relevant
 Nix invocations.
@@ -382,6 +373,50 @@ The following options are supported on flake-enabled CLIs:
 *--override-input* is specified slightly differently; for *nixos-cli* to pass it
 through properly, pass the input name and value as a single argument separated
 by an equals sign, rather than as two arguments in the actual Nix CLI.
+
+# ACTIVATION
+
+Activation happens in one of two ways depending on the target host the NixOS
+configuration is deployed to.
+
+If the target host is the local system, then activation simply consists of
+running the NixOS system closure's _switch-to-configuration_ script and ensuring
+it is successful. _switch-to-configuration_ could either be the stock one
+shipped with NixOS, or could possibly be an instance of _nixos activate_ if
+using the activation interface; see *nixos-cli-activate(1)* for more information.
+
+If local system activation fails, then the selected system profile (usually
+called _system_ unless *--profile-name* is passed) is automatically
+rolled back if it was changed. This ensures that a faulty NixOS system does not
+remain the selected generation in the system profile, since this would result
+in an unbootable system with no rollback capabilities if garbage collection was
+run at that point.
+
+However, if the target is a remote host accessed over SSH, then the default
+mode will run the _switch-to-configuration_ script on the target system, and
+will then wait for an acknowledgement signal from the invoking machine. This
+ensures that a connection from the invoking machine to the target is still
+available for further troubleshooting. If no
+acknowledgement signal is received within the configured time frame, then the
+target system automatically rolls back the configuration and runs the previous
+closure's _switch-to-configuration_ in order to re-establish the previously
+available SSH connection.
+
+Internally, this autonomous remote rollback process is referred to as a *magic
+rollback*, and is controlled by a transient _systemd_ unit that runs a shell
+script that controls this lifecycle. This shell script is internally called the
+*remote activation supervisor*.
+
+This *magic rollback* is similar in design to other NixOS deployment tools like
+_deploy-rs_, and takes heavy inspiration from them.
+
+In order to disable all rollback behavior for known working configurations 
+(such as when reboot is required for a successful activation or daemon restart,
+or when the SSH service/Internet will be modified/disabled on a remote system),
+use the *--no-rollback* flag or disable the _rollback.enable_ setting like
+this:
+
+	*nixos --config rollback.enable=false apply [options]*
 
 # SEE ALSO
 

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -193,6 +193,14 @@ global *--config* flag as such:
 	Skip registering the generation as a boot entry. Useful for testing a NixOS
 	system configuration, or for build-only runs.
 
+*--no-rollback*
+	Disable magic rollback mode when performing a remote switch, or disable
+	rolling back the current system profile if a local switch fails.
+
+	Useful when a machine is expected to lose the ability to receive an
+	acknowledgement, or when a switch-to-configuration invocation is expected
+	to fail.
+
 *-o*, *--output* <PATH>
 	Symlink the result of the build to the given *PATH*.
 
@@ -222,6 +230,18 @@ global *--config* flag as such:
 	password twice if NOPASSWD is not set for that user.
 
 	The escalation command used is defined by the setting _root_command_.
+
+*--rollback-timeout* <PERIOD>
+	The period of time to wait for the invoking machine to send an
+	acknowledgement signal before automatically rolling back the configuration.
+
+	*PERIOD* is a *systemd.time(7)*-formatted time span, such as *10s*. For more
+	information, see the *systemd.time(7)* man page.
+
+	Must be at least 1 second in length or more.
+
+	This is only applicable to remote activations with magic rollback mode
+	enabled.
 
 *-s*, *--specialisation* <NAME>
 	Activate a specialisation *NAME* from the available specialisations.

--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -104,10 +104,10 @@ Do not set directly unless running this in development.
 	recursing when a user invokes it directly.
 
 *NIXOS_CLI_DEBUG_MODE*
-	Show some extra log messages and otherwise other useful things during
+	Show some extra log messages and other useful diagnostic output during
 	development or debugging. Usually only useful during development,
-	but can be helpful when debugging other issues that are too verbose
-	to hide behind a flag.
+	but can be helpful when diagnosing issues whose verbosity is too high
+	to enable behind a dedicated flag by default.
 
 *\_\_NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE*
 	Set to prevent user activation invocations from infinitely recursing.

--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -104,8 +104,10 @@ Do not set directly unless running this in development.
 	recursing when a user invokes it directly.
 
 *NIXOS_CLI_DEBUG_MODE*
-	Show log messages for when developing TUIs. Only useful for during
-	development.
+	Show some extra log messages and otherwise other useful things during
+	development or debugging. Usually only useful during development,
+	but can be helpful when debugging other issues that are too verbose
+	to hide behind a flag.
 
 *\_\_NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE*
 	Set to prevent user activation invocations from infinitely recursing.

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -396,7 +396,7 @@ func RunActivationSupervisor(
 
 	ackTimeout := int(opts.AckTimeout / time.Second)
 	if ackTimeout < 1 {
-		return fmt.Errorf("acknowledgement timeout must be greater than 1 second")
+		return fmt.Errorf("acknowledgement timeout must be at least 1 second")
 	}
 	argv = append(argv, "-E", fmt.Sprintf("ACK_TIMEOUT=%d", ackTimeout))
 

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -417,8 +417,8 @@ func RunActivationSupervisor(
 
 	activationComplete := make(chan error, 1)
 	go func() {
-		_, err := s.Run(cmd)
-		activationComplete <- err
+		_, activationErr := s.Run(cmd)
+		activationComplete <- activationErr
 	}()
 
 	successTriggerCheckTimer := time.NewTicker(500 * time.Millisecond)

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -1,18 +1,28 @@
 package activation
 
 import (
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/nix-community/nixos-cli/internal/constants"
 	"github.com/nix-community/nixos-cli/internal/generation"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
+)
+
+const (
+	ACTIVATION_LOCKFILE = "/run/nixos/switch-to-configuration.lock"
+	SWITCH_SUCCESS_PATH = "/run/nixos/switch-success"
 )
 
 // Parse the generation's `nixos-cli` configuration to find the default specialisation
@@ -264,4 +274,203 @@ func SwitchToConfiguration(s system.CommandRunner, generationLocation string, ac
 
 	_, err := s.Run(cmd)
 	return err
+}
+
+// Create an activation trigger path name from a NixOS system
+// closure's location.
+//
+// Used for remote activation.
+func MakeActivationTriggerPath(systemLocation string) string {
+	// Obtain the cryptographic hash + nixos system closure name
+	basename := filepath.Base(systemLocation)
+
+	hash, _, found := strings.Cut(basename, "-")
+	if !found {
+		// Use the SHA256 hash of the whole path if the hash
+		// part in the filename is not found. This should be
+		// rare, if it happens at all, so this ensures collisions
+		// do not happen most of the time.
+		hashedBasename := sha256.Sum256([]byte(systemLocation))
+		hash = hex.EncodeToString(hashedBasename[:])
+	}
+
+	return filepath.Join(constants.NixOSActivationDirectory, "trigger", hash)
+}
+
+// Create the activation runtime directories with the required
+// structure.
+//
+// This creates the trigger directory as sticky, in case non-root users
+// need to activate things.
+//
+// NOTE: this trigger directory is world-writable to enable non-root users
+// to create files in it. This will need to be revisited if the ACK
+// trigger needs to be secure in the future.
+func EnsureActivationDirectoryExists() error {
+	err := os.MkdirAll(constants.NixOSActivationDirectory, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %s", constants.NixOSActivationDirectory, err)
+	}
+
+	triggerDirectory := filepath.Join(constants.NixOSActivationDirectory, "trigger")
+
+	err = os.MkdirAll(triggerDirectory, 0o777|os.ModeSticky)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %s", triggerDirectory, err)
+	}
+
+	err = os.Chmod(triggerDirectory, 0o777|os.ModeSticky)
+	if err != nil {
+		return fmt.Errorf("failed to set permissions for %s: %s", triggerDirectory, err)
+	}
+
+	return nil
+}
+
+type RunActivationSupervisorOptions struct {
+	ProfileName       string
+	InstallBootloader bool
+	Specialisation    string
+	UseRootCommand    bool
+	RootElevator      *system.RootElevator
+
+	PreviousSpecialisation   string
+	RollbackProfileOnFailure bool
+}
+
+//go:embed supervisor.sh
+var activationSupervisorScript string
+
+func RunActivationSupervisor(
+	s system.System,
+	systemLocation string,
+	action SwitchToConfigurationAction,
+	opts *RunActivationSupervisorOptions,
+) error {
+	log := s.Logger()
+
+	argv := []string{
+		"systemd-run",
+		"--collect",
+		"--no-ask-password",
+		"--pipe",
+		"--quiet",
+		"--service-type=exec",
+		"--unit=nixos-cli-activation-supervisor",
+		"--wait",
+		"-E", "PATH",
+		"-E", fmt.Sprintf("TOPLEVEL=%s", systemLocation),
+		"-E", fmt.Sprintf("ACTION=%s", action.String()),
+	}
+
+	if opts.Specialisation != "" {
+		argv = append(argv, "-E", fmt.Sprintf("SPECIALISATION=%s", opts.Specialisation))
+	}
+
+	if opts.PreviousSpecialisation != "" {
+		argv = append(argv, "-E", fmt.Sprintf("PREVIOUS_SPECIALISATION=%s", opts.PreviousSpecialisation))
+	}
+
+	if opts.ProfileName != "" {
+		profileDirectory := generation.GetProfileDirectoryFromName(opts.ProfileName)
+		argv = append(argv, "-E", fmt.Sprintf("PROFILE=%s", profileDirectory))
+	}
+
+	successTrigger := MakeActivationTriggerPath(systemLocation)
+	argv = append(argv, "-E", fmt.Sprintf("ACK_TRIGGER_PATH=%s", successTrigger))
+
+	if opts.RollbackProfileOnFailure {
+		argv = append(argv, "-E", "ROLLBACK_PROFILE_ON_FAILURE=1")
+	}
+
+	argv = append(argv, "-E", "LOCALE_ARCHIVE")
+
+	if opts.InstallBootloader {
+		argv = append(argv, "-E", "NIXOS_INSTALL_BOOTLOADER=1")
+	}
+
+	if log.GetLogLevel() == logger.LogLevelDebug {
+		argv = append(argv, "-E", "VERBOSE=1")
+	}
+
+	argv = append(argv, "/bin/sh", "-c", activationSupervisorScript)
+
+	if os.Getenv("NIXOS_CLI_DEBUG_MODE") != "" {
+		log.CmdArray(argv)
+	} else {
+		displayArgv := append([]string(nil), argv[0:len(argv)-1]...)
+		displayArgv = append(displayArgv, "<ACTIVATION-SCRIPT>")
+		log.CmdArray(displayArgv)
+	}
+
+	cmd := system.NewCommand(argv[0], argv[1:]...)
+	if opts.UseRootCommand {
+		cmd.AsRoot(opts.RootElevator)
+	}
+
+	activationComplete := make(chan error, 1)
+	go func() {
+		_, err := s.Run(cmd)
+		activationComplete <- err
+	}()
+
+	successTriggerCheckTimer := time.NewTicker(500 * time.Millisecond)
+	defer successTriggerCheckTimer.Stop()
+
+	successDetected := false
+	for !successDetected {
+		select {
+		case err := <-activationComplete:
+			// Check one more time if a success trigger has been created, in case
+			// the activation error returned before the ticker.
+			// This should be almost impossible, but just in case it happens, the
+			// final check is here.
+			if _, statErr := s.FS().Stat(SWITCH_SUCCESS_PATH); statErr == nil {
+				successDetected = true
+				break
+			}
+
+			// At this point, the supervisor exited before the success file appeared,
+			// so the switch has either failed, or a transport error has occurred
+			// and we need to re-initiate the SSH connection.
+			// FIXME: we need to still try and create the ACK file
+			// in case the connection was terminated, with a new
+			// SSH client.
+			if err != nil {
+				return fmt.Errorf("activation supervisor exited early: %w", err)
+			}
+			return fmt.Errorf("activation supervisor exited without success signal")
+		case <-successTriggerCheckTimer.C:
+			// Check for the existence of the switch success trigger.
+			// If it exists, then the switch has completed
+			// and we can proceed to signaling the watchdog.
+			_, err := s.FS().Stat(SWITCH_SUCCESS_PATH)
+			if err == nil {
+				successDetected = true
+				break
+			}
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("failed checking success file: %w", err)
+		}
+	}
+
+	// TODO: reconnect system connection first if SSH was restarted
+
+	err := s.FS().CreateFile(successTrigger)
+	if err != nil {
+		log.Errorf("failed to create %v on remote system: %v", successTrigger, err)
+	}
+
+	// Wait for the watchdog to either rollback or finish.
+	// If the SSH connection is broken, then this case
+	// cannot be hit because the connection was
+	// already terminated with a broken pipe.
+	err = <-activationComplete
+	if err != nil {
+		return fmt.Errorf("activation supervisor exited with error: %v", err)
+	}
+
+	return nil
 }

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -333,6 +333,7 @@ type RunActivationSupervisorOptions struct {
 	Specialisation    string
 	UseRootCommand    bool
 	RootElevator      *system.RootElevator
+	AckTimeout        time.Duration
 
 	PreviousSpecialisation   string
 	RollbackProfileOnFailure bool
@@ -392,6 +393,12 @@ func RunActivationSupervisor(
 	if log.GetLogLevel() == logger.LogLevelDebug {
 		argv = append(argv, "-E", "VERBOSE=1")
 	}
+
+	ackTimeout := int(opts.AckTimeout / time.Second)
+	if ackTimeout < 1 {
+		return fmt.Errorf("acknowledgement timeout must be greater than 1 second")
+	}
+	argv = append(argv, "-E", fmt.Sprintf("ACK_TIMEOUT=%d", ackTimeout))
 
 	argv = append(argv, "/bin/sh", "-c", activationSupervisorScript)
 

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -348,7 +348,7 @@ func RunActivationSupervisor(
 	systemLocation string,
 	action SwitchToConfigurationAction,
 	opts *RunActivationSupervisorOptions,
-) error {
+) (err error) {
 	if _, ok := s.(*system.SSHSystem); !ok {
 		panic("RunActivationSupervisor() called with a non-SSH system")
 	}
@@ -420,6 +420,28 @@ func RunActivationSupervisor(
 		cmd.AsRoot(opts.RootElevator)
 	}
 
+	// If the root elevator uses TTY input, then debug logs will
+	// not work since the terminal will be forced into raw mode.
+	//
+	// As such, any debug logging during the ACK process must be
+	// delayed and replayed later.
+	//
+	// This is a rather niche edge case, but it is useful nonetheless
+	// for users of `doas` and other root elevators that require
+	// TTY input.
+	supervisorLogger := log
+	if opts.RootElevator != nil && opts.RootElevator.Method == settings.PasswordInputMethodTTY {
+		log.Warn("terminal is in raw mode; will replay some supervisor logs after completion")
+		replayLogger := logger.NewReplayLogger(log)
+		defer func() {
+			if err != nil && replayLogger.HasEntries() {
+				log.Print("--- LOG OUTPUT DURING ACTIVATION: ---")
+				replayLogger.Flush()
+			}
+		}()
+		supervisorLogger = replayLogger
+	}
+
 	activationComplete := make(chan error, 1)
 	go func() {
 		// FIXME: there are times where if a connection is taken
@@ -436,7 +458,7 @@ func RunActivationSupervisor(
 	activationChConsumed := false
 	for !successDetected {
 		select {
-		case err := <-activationComplete:
+		case activationErr := <-activationComplete:
 			// Check one more time if a success trigger has been created, in case
 			// the activation error returned before the ticker.
 			// This should be almost impossible, but just in case it happens, the
@@ -451,43 +473,43 @@ func RunActivationSupervisor(
 			// so the switch has either failed, or a transport error has occurred
 			// and we need to re-initiate the SSH connection.
 
-			if _, ok := err.(*ssh.ExitMissingError); ok {
+			if _, ok := activationErr.(*ssh.ExitMissingError); ok {
 				log.Warn("lost connection to target host, attempting to reconnect")
-				err = s.(*system.SSHSystem).Reconnect()
-				if err != nil {
-					log.Errorf("%v", err)
+				activationErr = s.(*system.SSHSystem).Reconnect()
+				if activationErr != nil {
+					log.Errorf("%v", activationErr)
 					log.Info("the target host should rollback soon")
-					return err
+					return activationErr
 				}
 
 				log.Debug("attempting to acknowledge success after reconnecting")
-				if err = s.FS().CreateFile(successTrigger); err != nil {
-					log.Errorf("failed to create %v on remote system: %v", successTrigger, err)
+				if activationErr = s.FS().CreateFile(successTrigger); activationErr != nil {
+					log.Errorf("failed to create %v on remote system: %v", successTrigger, activationErr)
 					log.Info("the target host should rollback soon")
-					return err
+					return activationErr
 				}
 				return nil
 			}
 
 			// At this point, the SSH command has failed to run and
 			// we cannot do anything more, so exit with an error.
-			if err != nil {
-				return fmt.Errorf("activation supervisor exited early: %w", err)
+			if activationErr != nil {
+				return fmt.Errorf("activation supervisor exited early: %w", activationErr)
 			}
 			return errors.New("activation supervisor exited without success signal")
 		case <-successTriggerCheckTimer.C:
 			// Check for the existence of the switch success trigger.
 			// If it exists, then the switch has completed
 			// and we can proceed to signaling the watchdog.
-			_, err := s.FS().Stat(SWITCH_SUCCESS_PATH)
-			if err == nil {
+			_, statErr := s.FS().Stat(SWITCH_SUCCESS_PATH)
+			if statErr == nil {
 				successDetected = true
 				break
 			}
-			if errors.Is(err, os.ErrNotExist) {
+			if errors.Is(statErr, os.ErrNotExist) {
 				continue
 			}
-			return fmt.Errorf("failed checking success file: %w", err)
+			return fmt.Errorf("failed checking success file: %w", statErr)
 		}
 	}
 
@@ -496,12 +518,12 @@ func RunActivationSupervisor(
 	reconnectCh := make(chan *system.SSHSystem)
 
 	go func() {
-		log.Debug("attempting reconnect")
-		s2, err := s.(*system.SSHSystem).Clone()
-		if err != nil {
-			log.Errorf("%v", err)
-			log.Warnf("it is very likely that SSH access cannot be re-established")
-			log.Warnf("the target host should rollback soon")
+		supervisorLogger.Debug("attempting reconnect")
+		s2, reconnectErr := s.(*system.SSHSystem).Clone()
+		if reconnectErr != nil {
+			supervisorLogger.Errorf("%v", reconnectErr)
+			supervisorLogger.Warnf("it is very likely that SSH access cannot be re-established")
+			supervisorLogger.Warnf("the target host should rollback soon")
 			reconnectCh <- nil
 			return
 		}
@@ -515,16 +537,16 @@ func RunActivationSupervisor(
 		}
 
 		defer s2.Close()
-		err := s2.FS().CreateFile(successTrigger)
-		if err != nil {
-			log.Errorf("failed to create %v on remote system: %v", successTrigger, err)
+		createErr := s2.FS().CreateFile(successTrigger)
+		if createErr != nil {
+			supervisorLogger.Errorf("failed to create %v on remote system: %v", successTrigger, createErr)
 		}
 	case <-time.After(opts.AckTimeout):
 		// FIXME: fix race condition where s2 is never closed if this is reached first.
 		break
 	}
 
-	log.Debug("waiting for activation process to complete")
+	supervisorLogger.Debug("waiting for activation process to complete")
 
 	if !activationChConsumed {
 		// Wait for the watchdog to either rollback or finish.

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -348,6 +349,10 @@ func RunActivationSupervisor(
 	action SwitchToConfigurationAction,
 	opts *RunActivationSupervisorOptions,
 ) error {
+	if _, ok := s.(*system.SSHSystem); !ok {
+		panic("RunActivationSupervisor() called with a non-SSH system")
+	}
+
 	log := s.Logger()
 
 	argv := []string{
@@ -417,6 +422,9 @@ func RunActivationSupervisor(
 
 	activationComplete := make(chan error, 1)
 	go func() {
+		// FIXME: there are times where if a connection is taken
+		// down using `ip link set down`, then the whole process
+		// hangs. Figure out a way to detect this condition.
 		_, activationErr := s.Run(cmd)
 		activationComplete <- activationErr
 	}()
@@ -425,6 +433,7 @@ func RunActivationSupervisor(
 	defer successTriggerCheckTimer.Stop()
 
 	successDetected := false
+	activationChConsumed := false
 	for !successDetected {
 		select {
 		case err := <-activationComplete:
@@ -434,19 +443,38 @@ func RunActivationSupervisor(
 			// final check is here.
 			if _, statErr := s.FS().Stat(SWITCH_SUCCESS_PATH); statErr == nil {
 				successDetected = true
+				activationChConsumed = true
 				break
 			}
 
 			// At this point, the supervisor exited before the success file appeared,
 			// so the switch has either failed, or a transport error has occurred
 			// and we need to re-initiate the SSH connection.
-			// FIXME: we need to still try and create the ACK file
-			// in case the connection was terminated, with a new
-			// SSH client.
+
+			if _, ok := err.(*ssh.ExitMissingError); ok {
+				log.Warn("lost connection to target host, attempting to reconnect")
+				err = s.(*system.SSHSystem).Reconnect()
+				if err != nil {
+					log.Errorf("%v", err)
+					log.Info("the target host should rollback soon")
+					return err
+				}
+
+				log.Debug("attempting to acknowledge success after reconnecting")
+				if err = s.FS().CreateFile(successTrigger); err != nil {
+					log.Errorf("failed to create %v on remote system: %v", successTrigger, err)
+					log.Info("the target host should rollback soon")
+					return err
+				}
+				return nil
+			}
+
+			// At this point, the SSH command has failed to run and
+			// we cannot do anything more, so exit with an error.
 			if err != nil {
 				return fmt.Errorf("activation supervisor exited early: %w", err)
 			}
-			return fmt.Errorf("activation supervisor exited without success signal")
+			return errors.New("activation supervisor exited without success signal")
 		case <-successTriggerCheckTimer.C:
 			// Check for the existence of the switch success trigger.
 			// If it exists, then the switch has completed
@@ -463,20 +491,50 @@ func RunActivationSupervisor(
 		}
 	}
 
-	// TODO: reconnect system connection first if SSH was restarted
+	// Create a new target host connection, since SSH sessions
+	// will not terminate if sshd itself has terminated.
+	reconnectCh := make(chan *system.SSHSystem)
 
-	err := s.FS().CreateFile(successTrigger)
-	if err != nil {
-		log.Errorf("failed to create %v on remote system: %v", successTrigger, err)
+	go func() {
+		log.Debug("attempting reconnect")
+		s2, err := s.(*system.SSHSystem).Clone()
+		if err != nil {
+			log.Errorf("%v", err)
+			log.Warnf("it is very likely that SSH access cannot be re-established")
+			log.Warnf("the target host should rollback soon")
+			reconnectCh <- nil
+			return
+		}
+		reconnectCh <- s2
+	}()
+
+	select {
+	case s2 := <-reconnectCh:
+		if s2 == nil {
+			break
+		}
+
+		defer s2.Close()
+		err := s2.FS().CreateFile(successTrigger)
+		if err != nil {
+			log.Errorf("failed to create %v on remote system: %v", successTrigger, err)
+		}
+	case <-time.After(opts.AckTimeout):
+		// FIXME: fix race condition where s2 is never closed if this is reached first.
+		break
 	}
 
-	// Wait for the watchdog to either rollback or finish.
-	// If the SSH connection is broken, then this case
-	// cannot be hit because the connection was
-	// already terminated with a broken pipe.
-	err = <-activationComplete
-	if err != nil {
-		return fmt.Errorf("activation supervisor exited with error: %v", err)
+	log.Debug("waiting for activation process to complete")
+
+	if !activationChConsumed {
+		// Wait for the watchdog to either rollback or finish.
+		// If the SSH connection is broken, then this case
+		// cannot be hit because the connection was
+		// already terminated with a broken pipe.
+		activationErr := <-activationComplete
+		if activationErr != nil {
+			return fmt.Errorf("activation supervisor exited with error: %w", activationErr)
+		}
 	}
 
 	return nil

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -524,10 +524,19 @@ func RunActivationSupervisor(
 			supervisorLogger.Errorf("%v", reconnectErr)
 			supervisorLogger.Warnf("it is very likely that SSH access cannot be re-established")
 			supervisorLogger.Warnf("the target host should rollback soon")
-			reconnectCh <- nil
+			close(reconnectCh)
 			return
 		}
-		reconnectCh <- s2
+
+		select {
+		case reconnectCh <- s2:
+			// Do nothing, the connection has been re-established here.
+			break
+		case <-time.After(opts.AckTimeout):
+			// Otherwise, close the connection since no other
+			// goroutine will pick it up.
+			s2.Close()
+		}
 	}()
 
 	select {
@@ -542,7 +551,9 @@ func RunActivationSupervisor(
 			supervisorLogger.Errorf("failed to create %v on remote system: %v", successTrigger, createErr)
 		}
 	case <-time.After(opts.AckTimeout):
-		// FIXME: fix race condition where s2 is never closed if this is reached first.
+		// Once the timeout is hit, the reconnect goroutine
+		// will automatically close the connection since it
+		// wasn't received here.
 		break
 	}
 

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -166,6 +166,34 @@ func SetNixProfileGeneration(s system.System, profile string, genNumber uint64, 
 	return err
 }
 
+type RollbackNixProfileOptions struct {
+	UseRootCommand bool
+	RootElevator   *system.RootElevator
+}
+
+func RollbackNixProfile(s system.System, profile string, opts *RollbackNixProfileOptions) error {
+	if profile != "system" {
+		err := EnsureSystemProfileDirectoryExists(s)
+		if err != nil {
+			return err
+		}
+	}
+
+	profileDirectory := generation.GetProfileDirectoryFromName(profile)
+
+	argv := []string{"nix-env", "--profile", profileDirectory, "--rollback"}
+
+	s.Logger().CmdArray(argv)
+
+	cmd := system.NewCommand(argv[0], argv[1:]...)
+	if opts.UseRootCommand {
+		cmd.AsRoot(opts.RootElevator)
+	}
+
+	_, err := s.Run(cmd)
+	return err
+}
+
 func GetCurrentGenerationNumber(s system.System, profile string) (uint64, error) {
 	genLinkRegex, err := regexp.Compile(fmt.Sprintf(generation.GenerationLinkTemplateRegex, profile))
 	if err != nil {

--- a/internal/activation/supervisor.sh
+++ b/internal/activation/supervisor.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# The activation directory may not exist at this point,
-# and creating the lockfile would fail otherwise.
+# The activation directories may not exist at this point,
+# and creating the lockfile/triggers would fail otherwise.
 mkdir -p /run/nixos
+mkdir -m 1777 /run/nixos/trigger
 
 # Concurrent supervisors are prohibited.
 # Otherwise, multiple rollbacks and switch-to-configuration

--- a/internal/activation/supervisor.sh
+++ b/internal/activation/supervisor.sh
@@ -123,11 +123,10 @@ touch "$SWITCH_SUCCESS_PATH"
 
 log "waiting for acknowledgement"
 
-# Poll for the file once a second for 30 seconds; this is a POSIX sh
+# Poll for the file once a second for $ACK_TIMEOUT seconds; this is a POSIX sh
 # substitute for `inotifywait` to avoid introducing additional dependencies.
-# TODO: make this timeout configurable
 i=0
-while [ "$i" -lt 30 ]; do
+while [ "$i" -lt "$ACK_TIMEOUT" ]; do
 	if [ -f "$ACK_TRIGGER_PATH" ]; then
 		log "acknowledgement received; activation is now complete"
 		exit 0

--- a/internal/activation/supervisor.sh
+++ b/internal/activation/supervisor.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+# The activation directory may not exist at this point,
+# and creating the lockfile would fail otherwise.
+mkdir -p /run/nixos
+
+# Concurrent supervisors are prohibited.
+# Otherwise, multiple rollbacks and switch-to-configuration
+# invocations could have a chance of occurring and makes
+# error output super confusing.
+LOCKFILE=/run/nixos/activation-supervisor.lock
+SWITCH_LOCKFILE=/run/nixos/switch-to-configuration.lock
+
+# The appearance of this path signals to the command invoker
+# that the initial switch-to-configuration has completed
+# without any errors.
+SWITCH_SUCCESS_PATH=/run/nixos/switch-success
+
+log() {
+	echo "$@" >&2
+}
+
+if [ "$ACK_TIMEOUT" = "" ] || ! [ "$ACK_TIMEOUT" -gt 0 ] 2>/dev/null; then
+	log "ACK_TIMEOUT must be set to a positive integer"
+	exit 1
+fi
+
+if [ "$ACK_TRIGGER_PATH" = "" ]; then
+	log "ACK_TRIGGER_PATH must be set"
+	exit 1
+fi
+
+if [ "$TOPLEVEL" = "" ]; then
+	log "TOPLEVEL must be set"
+	exit 1
+fi
+
+if [ "$ACTION" = "" ]; then
+	log "ACTION must be set"
+	exit 1
+fi
+
+# Pass in -v to switch-to-configuration runs if this is set.
+verbose_flag=
+if [ "$VERBOSE" != "" ]; then
+	verbose_flag="-v"
+fi
+
+# Remove stale entries for the file signals,
+# and make sure they are removed if exiting or interrupted.
+rm -f "$ACK_TRIGGER_PATH" "$SWITCH_SUCCESS_PATH"
+trap 'rm -f "$ACK_TRIGGER_PATH" "$SWITCH_SUCCESS_PATH"' EXIT INT TERM HUP QUIT
+
+# Use fd 7 to obtain the process lock.
+exec 7>"$LOCKFILE" || {
+	log "failed to map fd 7 to $LOCKFILE"
+	exit 1
+}
+
+flock -n 7 || {
+	log "failed to lock $LOCKFILE; is another activation process running?"
+	exit 1
+}
+
+# If a specialisation is passed by the caller, then use that
+# switch-to-configuration script instead.
+if [ "$SPECIALISATION" = "" ]; then
+	switchToConfigurationScript="$TOPLEVEL/bin/switch-to-configuration"
+else
+	switchToConfigurationScript="$TOPLEVEL/specialisation/$SPECIALISATION/bin/switch-to-configuration"
+fi
+
+# Save the previous generation's path now in case a rollback
+# needs to be run.
+prevToplevel=$(readlink /run/current-system)
+
+rollback() {
+	# $ROLLBACK_PROFILE_ON_FAILURE will not be set when switching
+	# from a system that does not exist in the generation list,
+	# such as when switching from a generation built with
+	# `nixos apply --no-boot` or `nixos-rebuild test` to another
+	# one.
+	if [ "$ROLLBACK_PROFILE_ON_FAILURE" != "" ]; then
+		# FIXME: --rollback may not be the correct solution for the system profile!
+		# may need to specify explicit generation number
+		nix-env -p "$PROFILE" --rollback $verbose_flag
+	fi
+
+	# If a previous specialisation is detected by the caller, then use it.
+	if [ "$PREVIOUS_SPECIALISATION" = "" ]; then
+		prevSwitchToConfigurationScript="$prevToplevel/bin/switch-to-configuration"
+	else
+		prevSwitchToConfigurationScript="$prevToplevel/specialisation/$PREVIOUS_SPECIALISATION/bin/switch-to-configuration"
+	fi
+
+	"$prevSwitchToConfigurationScript" "$ACTION" $verbose_flag
+
+	exit 1
+}
+
+# Run the switch, and immediately rollback if it fails.
+if ! "$switchToConfigurationScript" "$ACTION" $verbose_flag; then
+	rollback
+fi
+
+# Obtain a switch-to-configuration lock now on fd 8, to make sure
+# no standalone switch-to-configuration processes acquire the lock
+exec 8>"$SWITCH_LOCKFILE" || {
+	log "failed to map fd 8 to $SWITCH_LOCKFILE"
+	exit 1
+}
+
+flock -n 8 || {
+	log "failed to lock $SWITCH_LOCKFILE; another activation process may have stolen the limelight"
+	log "running switch-to-configuration during the acknowledgement watchdog process is strongly not recommended"
+	log "not attempting to proceed with rollback detection"
+	exit 1
+}
+
+# Signal to callers that switch-to-configuration has been run, and
+# that we are now waiting for an acknowledgement of it.
+touch "$SWITCH_SUCCESS_PATH"
+
+log "waiting for acknowledgement"
+
+# Poll for the file once a second for 30 seconds; this is a POSIX sh
+# substitute for `inotifywait` to avoid introducing additional dependencies.
+# TODO: make this timeout configurable
+i=0
+while [ "$i" -lt 30 ]; do
+	if [ -f "$ACK_TRIGGER_PATH" ]; then
+		log "acknowledgement received; activation is now complete"
+		exit 0
+	fi
+
+	sleep 1
+	i=$((i + 1))
+done
+
+if [ -f "$ACK_TRIGGER_PATH" ]; then
+	log "acknowledgement received; activation is now complete"
+	exit 0
+fi
+
+flock -un 8
+
+log "no acknowledgement was received from invoking machine; starting rollback"
+rollback

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -22,23 +22,25 @@ type AliasesOpts struct {
 }
 
 type ApplyOpts struct {
-	File                  string
-	Attr                  string
 	AlwaysConfirm         bool
+	Attr                  string
 	BuildHost             string
 	BuildImage            string
 	BuildVM               bool
 	BuildVMWithBootloader bool
 	Dry                   bool
+	File                  string
 	FlakeRef              string
 	GenerationTag         string
 	InstallBootloader     bool
+	LocalRoot             bool
 	NoActivate            bool
 	NoBoot                bool
+	NoRollback            bool
 	OutputPath            string
 	ProfileName           string
-	LocalRoot             bool
 	RemoteRoot            bool
+	RollbackTimeout       string
 	Specialisation        string
 	StorePath             string
 	TargetHost            string

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -4,6 +4,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/activation"
 	"github.com/nix-community/nixos-cli/internal/cmd/nixopts"
 	"github.com/nix-community/nixos-cli/internal/configuration"
+	systemdUtils "github.com/nix-community/nixos-cli/internal/systemd"
 )
 
 type MainOpts struct {
@@ -40,7 +41,7 @@ type ApplyOpts struct {
 	OutputPath            string
 	ProfileName           string
 	RemoteRoot            bool
-	RollbackTimeout       string
+	RollbackTimeout       systemdUtils.SystemdDuration
 	Specialisation        string
 	StorePath             string
 	TargetHost            string
@@ -121,7 +122,7 @@ type GenerationDeleteOpts struct {
 	// but Cobra's pflags does not support this type yet.
 	Keep          []uint
 	MinimumToKeep uint64
-	OlderThan     string
+	OlderThan     systemdUtils.SystemdDuration
 	UpperBound    uint64
 	AlwaysConfirm bool
 	Pattern       string

--- a/internal/cmd/utils/utils.go
+++ b/internal/cmd/utils/utils.go
@@ -66,3 +66,14 @@ func AlignedOptions(options map[string]string) string {
 
 	return result
 }
+
+// Remove the default value string for a given flag, if it exists.
+// This is useful for disabling zero value defaults in command
+// flag descriptions.
+func RemoveDefaultValueDesc(cmd *cobra.Command, flags ...string) {
+	for _, flag := range flags {
+		if f := cmd.Flags().Lookup(flag); f != nil {
+			f.DefValue = ""
+		}
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,12 +1,13 @@
 package constants
 
 const (
-	NixProfileDirectory       = "/nix/var/nix/profiles"
-	NixSystemProfileDirectory = NixProfileDirectory + "/system-profiles"
-	DefaultConfigLocation     = "/etc/nixos-cli/config.toml"
 	CurrentSystem             = "/run/current-system"
-	NixOSMarker               = "/etc/NIXOS"
+	DefaultConfigLocation     = "/etc/nixos-cli/config.toml"
 	NixChannelDirectory       = NixProfileDirectory + "/per-user/root/channels"
+	NixOSActivationDirectory  = "/run/nixos"
+	NixOSMarker               = "/etc/NIXOS"
 	NixOSVersionFile          = "nixos-version"
+	NixProfileDirectory       = "/nix/var/nix/profiles"
 	NixStoreDatabase          = "/nix/var/nix/db/db.sqlite"
+	NixSystemProfileDirectory = NixProfileDirectory + "/system-profiles"
 )

--- a/internal/generation/completion.go
+++ b/internal/generation/completion.go
@@ -10,6 +10,7 @@ import (
 
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/constants"
+	"github.com/nix-community/nixos-cli/internal/system"
 	"github.com/spf13/cobra"
 )
 
@@ -41,12 +42,13 @@ func CompleteProfileFlag(_ *cobra.Command, args []string, toComplete string) ([]
 func CompleteGenerationNumber(profile *string, limit int) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		log, _ := cmdUtils.PrepareCompletionResources()
+		s := system.NewLocalSystem(log)
 
 		if limit != 0 && len(args) >= limit {
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		generations, err := CollectGenerationsInProfile(log, *profile)
+		generations, err := CollectGenerationsInProfile(s, log, *profile)
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -82,8 +84,9 @@ func CompleteGenerationNumber(profile *string, limit int) cobra.CompletionFunc {
 func CompleteGenerationNumberFlag(profile *string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		log, _ := cmdUtils.PrepareCompletionResources()
+		s := system.NewLocalSystem(log)
 
-		generations, err := CollectGenerationsInProfile(log, *profile)
+		generations, err := CollectGenerationsInProfile(s, log, *profile)
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/generation/generation.go
+++ b/internal/generation/generation.go
@@ -26,6 +26,7 @@ func GetProfileDirectoryFromName(profile string) string {
 }
 
 type Generation struct {
+	Path            string    `json:"path"`
 	Number          uint64    `json:"number"`
 	CreationDate    time.Time `json:"creation_date"`
 	IsCurrent       bool      `json:"is_current"`
@@ -56,7 +57,13 @@ func (e *GenerationReadError) Error() string {
 }
 
 func GenerationFromDirectory(s system.System, generationDirname string, number uint64) (*Generation, error) {
+	generationPath, err := s.FS().RealPath(generationDirname)
+	if err != nil {
+		generationPath = generationDirname
+	}
+
 	info := &Generation{
+		Path:            generationPath,
 		Number:          number,
 		CreationDate:    time.Time{},
 		IsCurrent:       false,

--- a/internal/generation/generation.go
+++ b/internal/generation/generation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/djherbis/times"
 	"github.com/nix-community/nixos-cli/internal/constants"
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/system"
 )
 
 func GetProfileDirectoryFromName(profile string) string {
@@ -54,7 +55,7 @@ func (e *GenerationReadError) Error() string {
 	return fmt.Sprintf("failed to read generation %d from directory %s", e.Number, e.Directory)
 }
 
-func GenerationFromDirectory(generationDirname string, number uint64) (*Generation, error) {
+func GenerationFromDirectory(s system.System, generationDirname string, number uint64) (*Generation, error) {
 	info := &Generation{
 		Number:          number,
 		CreationDate:    time.Time{},
@@ -67,7 +68,7 @@ func GenerationFromDirectory(generationDirname string, number uint64) (*Generati
 
 	encounteredErrors := []error{}
 
-	manifestBytes, err := os.ReadFile(nixosVersionManifestFile)
+	manifestBytes, err := s.FS().ReadFile(nixosVersionManifestFile)
 	if err != nil {
 		// The `nixos-version.json` file does not exist in generations that
 		// are created without the corresponding NixOS module enabled or
@@ -95,7 +96,8 @@ func GenerationFromDirectory(generationDirname string, number uint64) (*Generati
 		nixosVersionFile := filepath.Join(generationDirname, constants.NixOSVersionFile)
 
 		var nixosVersionContents []byte
-		nixosVersionContents, err = os.ReadFile(nixosVersionFile)
+		nixosVersionContents, err = s.FS().ReadFile(nixosVersionFile)
+
 		if err != nil {
 			encounteredErrors = append(encounteredErrors, err)
 		} else {
@@ -104,19 +106,23 @@ func GenerationFromDirectory(generationDirname string, number uint64) (*Generati
 	}
 
 	// Get time of creation for the generation
-	creationTimeStat, err := times.Stat(generationDirname)
-	if err != nil {
-		encounteredErrors = append(encounteredErrors, err)
-	} else {
-		if creationTimeStat.HasBirthTime() {
-			info.CreationDate = creationTimeStat.BirthTime()
+	switch s.(type) {
+	case *system.LocalSystem:
+		var creationTimeStat times.Timespec
+		creationTimeStat, err = times.Stat(generationDirname)
+		if err != nil {
+			encounteredErrors = append(encounteredErrors, err)
 		} else {
-			info.CreationDate = creationTimeStat.ModTime()
+			if creationTimeStat.HasBirthTime() {
+				info.CreationDate = creationTimeStat.BirthTime()
+			} else {
+				info.CreationDate = creationTimeStat.ModTime()
+			}
 		}
 	}
 
 	kernelVersionDirGlob := filepath.Join(generationDirname, "kernel-modules", "lib", "modules", "*")
-	kernelVersionMatches, err := filepath.Glob(kernelVersionDirGlob)
+	kernelVersionMatches, err := s.FS().Glob(kernelVersionDirGlob)
 	if err != nil {
 		encounteredErrors = append(encounteredErrors, err)
 	} else if len(kernelVersionMatches) == 0 {
@@ -125,7 +131,7 @@ func GenerationFromDirectory(generationDirname string, number uint64) (*Generati
 		info.KernelVersion = filepath.Base(kernelVersionMatches[0])
 	}
 
-	specialisations, err := CollectSpecialisations(generationDirname)
+	specialisations, err := CollectSpecialisations(s, generationDirname)
 	if err != nil {
 		encounteredErrors = append(encounteredErrors, err)
 	}
@@ -147,13 +153,13 @@ const (
 	GenerationLinkTemplateRegex = `^%s-(\d+)-link$`
 )
 
-func CollectGenerationsInProfile(log logger.Logger, profile string) ([]Generation, error) {
+func CollectGenerationsInProfile(s system.System, log logger.Logger, profile string) ([]Generation, error) {
 	profileDirectory := constants.NixProfileDirectory
 	if profile != "system" {
 		profileDirectory = constants.NixSystemProfileDirectory
 	}
 
-	generationDirEntries, err := os.ReadDir(profileDirectory)
+	generationDirEntries, err := s.FS().ReadDir(profileDirectory)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +171,7 @@ func CollectGenerationsInProfile(log logger.Logger, profile string) ([]Generatio
 	}
 
 	currentGenerationDirname := GetProfileDirectoryFromName(profile)
-	currentGenerationLink, err := os.Readlink(currentGenerationDirname)
+	currentGenerationLink, err := s.FS().ReadLink(currentGenerationDirname)
 	if err != nil {
 		log.Warnf("unable to determine current generation: %v", err)
 	}
@@ -185,7 +191,7 @@ func CollectGenerationsInProfile(log logger.Logger, profile string) ([]Generatio
 			generationDirectoryName := filepath.Join(profileDirectory, fmt.Sprintf("%s-%d-link", profile, genNumber))
 
 			var info *Generation
-			info, err = GenerationFromDirectory(generationDirectoryName, genNumber)
+			info, err = GenerationFromDirectory(s, generationDirectoryName, genNumber)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/generation/specialisations.go
+++ b/internal/generation/specialisations.go
@@ -9,15 +9,16 @@ import (
 
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/configuration"
+	"github.com/nix-community/nixos-cli/internal/system"
 	"github.com/spf13/cobra"
 )
 
-func CollectSpecialisations(generationDirname string) ([]string, error) {
+func CollectSpecialisations(s system.System, generationDirname string) ([]string, error) {
 	var specialisations []string
 
 	specialisationsGlob := filepath.Join(generationDirname, "specialisation", "*")
 
-	specialisationsMatches, err := filepath.Glob(specialisationsGlob)
+	specialisationsMatches, err := s.FS().Glob(specialisationsGlob)
 	if err != nil {
 		return nil, err
 	} else {
@@ -64,7 +65,10 @@ func CollectSpecialisationsFromConfig(cfg configuration.Configuration) []string 
 
 func CompleteSpecialisationFlag(generationDirname string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		specialisations, err := CollectSpecialisations(generationDirname)
+		log, _ := cmdUtils.PrepareCompletionResources()
+		s := system.NewLocalSystem(log)
+
+		specialisations, err := CollectSpecialisations(s, generationDirname)
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/logger/replay.go
+++ b/internal/logger/replay.go
@@ -1,0 +1,173 @@
+package logger
+
+import "slices"
+
+type ReplayLogger struct {
+	entries []logEntry
+	out     Logger
+}
+
+type logKind int
+
+const (
+	kindDebug logKind = iota
+	kindDebugf
+	kindInfo
+	kindInfof
+	kindWarn
+	kindWarnf
+	kindError
+	kindErrorf
+	kindPrint
+	kindPrintf
+	kindCmdArray
+	kindStep
+)
+
+type logEntry struct {
+	kind   logKind
+	format string
+	args   []any
+	argv   []string
+	msg    string
+}
+
+func NewReplayLogger(out Logger) *ReplayLogger {
+	return &ReplayLogger{
+		entries: make([]logEntry, 0, 64),
+		out:     out,
+	}
+}
+
+func (l *ReplayLogger) Flush() {
+	for _, e := range l.entries {
+		switch e.kind {
+		case kindDebug:
+			l.out.Debug(e.args...)
+		case kindDebugf:
+			l.out.Debugf(e.format, e.args...)
+		case kindInfo:
+			l.out.Info(e.args...)
+		case kindInfof:
+			l.out.Infof(e.format, e.args...)
+		case kindWarn:
+			l.out.Warn(e.args...)
+		case kindWarnf:
+			l.out.Warnf(e.format, e.args...)
+		case kindError:
+			l.out.Error(e.args...)
+		case kindErrorf:
+			l.out.Errorf(e.format, e.args...)
+		case kindPrint:
+			l.out.Print(e.args...)
+		case kindPrintf:
+			l.out.Printf(e.format, e.args...)
+		case kindCmdArray:
+			l.out.CmdArray(e.argv)
+		case kindStep:
+			l.out.Step(e.msg)
+		}
+	}
+	l.entries = l.entries[:0]
+}
+
+func (l *ReplayLogger) HasEntries() bool {
+	return len(l.entries) > 0
+}
+
+func (l *ReplayLogger) Print(v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindPrint,
+		args: v,
+	})
+}
+
+func (l *ReplayLogger) Printf(format string, v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind:   kindPrintf,
+		format: format,
+		args:   v,
+	})
+}
+
+func (l *ReplayLogger) Info(v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindInfo,
+		args: v,
+	})
+}
+
+func (l *ReplayLogger) Infof(format string, v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind:   kindInfof,
+		format: format,
+		args:   v,
+	})
+}
+
+func (l *ReplayLogger) Debug(v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindDebug,
+		args: v,
+	})
+}
+
+func (l *ReplayLogger) Debugf(format string, v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind:   kindDebugf,
+		format: format,
+		args:   v,
+	})
+}
+
+func (l *ReplayLogger) Warn(v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindWarn,
+		args: v,
+	})
+}
+
+func (l *ReplayLogger) Warnf(format string, v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind:   kindWarnf,
+		format: format,
+		args:   v,
+	})
+}
+
+func (l *ReplayLogger) Error(v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindError,
+		args: v,
+	})
+}
+
+func (l *ReplayLogger) Errorf(format string, v ...any) {
+	l.entries = append(l.entries, logEntry{
+		kind:   kindErrorf,
+		format: format,
+		args:   v,
+	})
+}
+
+func (l *ReplayLogger) Step(msg string) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindStep,
+		msg:  msg,
+	})
+}
+
+func (l *ReplayLogger) CmdArray(args []string) {
+	l.entries = append(l.entries, logEntry{
+		kind: kindCmdArray,
+		argv: slices.Clone(args),
+	})
+}
+
+func (l *ReplayLogger) GetLogLevel() LogLevel {
+	return l.out.GetLogLevel()
+}
+
+func (l *ReplayLogger) SetLogLevel(level LogLevel) {
+	// no-op, let log sink control which level they want
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -7,11 +7,13 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/knadh/koanf/parsers/toml/v2"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/knadh/koanf/v2"
+	systemdUtils "github.com/nix-community/nixos-cli/internal/systemd"
 )
 
 type Settings struct {
@@ -27,10 +29,13 @@ type Settings struct {
 	Option            OptionSettings       `koanf:"option"`
 	Root              RootCommandSettings  `koanf:"root"`
 	RootCommand       string               `koanf:"root_command"`
+	Rollback          RollbackSettings     `koanf:"rollback"`
 	SSH               SSHSettings          `koanf:"ssh"`
 	UseColor          bool                 `koanf:"color"`
 	UseDefaultAliases bool                 `koanf:"use_default_aliases"`
 	UseNvd            bool                 `koanf:"use_nvd"`
+
+	setDeprecatedFields map[string]struct{}
 }
 
 type ApplySettings struct {
@@ -69,6 +74,11 @@ type OptionSettings struct {
 	MinScore     int64 `koanf:"min_score"`
 	Prettify     bool  `koanf:"prettify"`
 	DebounceTime int64 `koanf:"debounce_time"`
+}
+
+type RollbackSettings struct {
+	Enable  bool                         `koanf:"enable"`
+	Timeout systemdUtils.SystemdDuration `koanf:"timeout"`
 }
 
 type RootCommandSettings struct {
@@ -212,6 +222,7 @@ const (
 	DeprecatedDocString = "This setting has been deprecated, and will be removed in a future release."
 
 	confirmationInputPossibleValues = "Possible values are `default-no` (treat as a no input), `default-yes` (treat as a yes input), or `retry` (try again)."
+	rollbackTimeoutDefaultValue     = systemdUtils.SystemdDuration(30 * time.Second)
 )
 
 var DefaultAliases = map[string][]string{
@@ -274,6 +285,7 @@ var SettingsDocs = map[string]SettingsDocEntry{
 			"In the case of remote activations, this will also run the previous switch-to-configuration if an " +
 			"acknowledgement from the invoking system is not received, in order to re-establish a connection " +
 			"for further troubleshooting.",
+		Deprecated: "Remove this field; rollback is now configured via `rollback.enable` (defaults to `true`).",
 	},
 	"color": {
 		Short: "Enable colored output",
@@ -366,6 +378,24 @@ This requires the 'nix-command' experimental feature to be enabled in the Nix co
 		Short: "Debounce time for searching options using the UI, in milliseconds",
 		Long:  "Controls how often search results are recomputed when typing in the options UI, in milliseconds.",
 	},
+	"rollback": {
+		Short: "Settings for automatic rollback upon failure",
+	},
+	"rollback.enable": {
+		Short: "Automatically rollback system on activation failure or lack of remote acknowledgement",
+		Long: `Enable automatic/"magic" rollback of a NixOS system profile when an activation command fails. This can be ` +
+			"disabled when a reboot or some other circumstance is needed for successful activation. " +
+			"In the case of remote activations, this will also run the previous switch-to-configuration if an " +
+			"acknowledgement from the invoking system is not received, in order to re-establish a connection " +
+			"for further troubleshooting.",
+	},
+	"rollback.timeout": {
+		Short: "Period of time to wait for an acknowledgement from the machine invoking an activation",
+		Long: "The period of time to wait for the invoking machine to send back an acknowledgement to " +
+			"the destination machine after a successful activation has been performed before performing a rollback. " +
+			`This only applies to remote/"magic" rollback mode for when remote activation of NixOS systems fails to be ` +
+			"acknowledged. The timeout is specified as a `systemd.time(7)`-formatted time span, and must be at least 1 second.",
+	},
 	"ssh": {
 		Short: "Settings for SSH",
 	},
@@ -429,7 +459,7 @@ This requires the 'nix-command' experimental feature to be enabled in the Nix co
 func NewSettings() *Settings {
 	return &Settings{
 		Aliases:        make(map[string][]string),
-		AutoRollback:   true,
+		AutoRollback:   false,
 		UseColor:       true,
 		ConfigLocation: "/etc/nixos",
 		Confirmation: ConfirmationSettings{
@@ -449,6 +479,10 @@ func NewSettings() *Settings {
 			Prettify:     true,
 			DebounceTime: 25,
 		},
+		Rollback: RollbackSettings{
+			Enable:  true,
+			Timeout: rollbackTimeoutDefaultValue,
+		},
 		Root: RootCommandSettings{
 			Command:        "sudo",
 			PasswordMethod: PasswordInputMethodStdin,
@@ -458,6 +492,8 @@ func NewSettings() *Settings {
 			HostKeyVerification: HostKeyVerificationAsk,
 		},
 		UseDefaultAliases: true,
+
+		setDeprecatedFields: make(map[string]struct{}),
 	}
 }
 
@@ -468,14 +504,7 @@ func ParseSettings(location string) (*Settings, error) {
 		return nil, err
 	}
 
-	cfg := NewSettings()
-
-	err := k.Unmarshal("", cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
+	return parse(k)
 }
 
 func ParseSettingsFromString(input string) (*Settings, error) {
@@ -485,11 +514,21 @@ func ParseSettingsFromString(input string) (*Settings, error) {
 		return nil, err
 	}
 
+	return parse(k)
+}
+
+func parse(k *koanf.Koanf) (*Settings, error) {
 	cfg := NewSettings()
 
 	err := k.Unmarshal("", cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	for key, field := range SettingsDocs {
+		if k.Exists(key) && field.Deprecated != "" {
+			cfg.setDeprecatedFields[key] = struct{}{}
+		}
 	}
 
 	return cfg, nil
@@ -566,6 +605,29 @@ func (cfg *Settings) Validate() SettingsErrors {
 		}
 	}
 
+	if cfg.AutoRollback {
+		errs = append(errs, DeprecatedSettingError{
+			Field:       "auto_rollback",
+			Alternative: "set `rollback.enable` to `true` instead",
+		})
+		cfg.Rollback.Enable = true
+	} else if _, exists := cfg.setDeprecatedFields["auto_rollback"]; exists {
+		errs = append(errs, DeprecatedSettingError{
+			Field:       "auto_rollback",
+			Alternative: "set `rollback.enable` to `false` instead",
+		})
+		cfg.Rollback.Enable = false
+	}
+
+	if cfg.Rollback.Timeout.Duration() < time.Second {
+		errs = append(errs, SettingsError{
+			Field:   "rollback.timeout",
+			Message: fmt.Sprintf("rollback.timeout must be at least 1 second long; using default (%s)", rollbackTimeoutDefaultValue.Duration().String()),
+		})
+
+		cfg.Rollback.Timeout = rollbackTimeoutDefaultValue
+	}
+
 	if len(errs) > 0 {
 		return errs
 	}
@@ -609,6 +671,7 @@ func (cfg *Settings) SetValue(key string, value string) error {
 					if err := unmarshaler.UnmarshalText([]byte(value)); err != nil {
 						return err
 					}
+					cfg.checkIfDeprecated(key)
 					return nil
 				}
 			}
@@ -638,11 +701,18 @@ func (cfg *Settings) SetValue(key string, value string) error {
 				return SettingsError{Field: field, Message: "unsupported field type"}
 			}
 
+			cfg.checkIfDeprecated(key)
 			return nil
 		}
 	}
 
 	return nil
+}
+
+func (cfg *Settings) checkIfDeprecated(key string) {
+	if doc, ok := SettingsDocs[key]; ok && doc.Deprecated != "" {
+		cfg.setDeprecatedFields[key] = struct{}{}
+	}
 }
 
 func isSettable(value *reflect.Value) bool {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -268,9 +268,12 @@ var SettingsDocs = map[string]SettingsDocEntry{
 			" or upgrading the root user's Nix channels.",
 	},
 	"auto_rollback": {
-		Short: "Automatically rollback profile on activation failure",
+		Short: "Automatically rollback system on activation failure or lack of remote acknowledgement",
 		Long: "Enables automatic rollback of a NixOS system profile when an activation command fails. This can be " +
-			"disabled when a reboot or some other circumstance is needed for successful activation",
+			"disabled when a reboot or some other circumstance is needed for successful activation. " +
+			"In the case of remote activations, this will also run the previous switch-to-configuration if an " +
+			"acknowledgement from the invoking system is not received, in order to re-establish a connection " +
+			"for further troubleshooting.",
 	},
 	"color": {
 		Short: "Enable colored output",

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -16,10 +16,12 @@ func TestValidateConfig(t *testing.T) {
 			"validalias":           {"value4"},
 			"validalias-noentries": {},
 		}
+		cfg.Option.MinScore = 1
+		cfg.Rollback.Timeout = 0
 
 		errs := cfg.Validate()
-		if len(errs) != 4 {
-			t.Errorf("expected 4 errors, got %d", len(errs))
+		if len(errs) != 5 {
+			t.Errorf("expected 5 errors, got %d", len(errs))
 		}
 
 		if len(cfg.Aliases) != 1 {

--- a/internal/system/elevator.go
+++ b/internal/system/elevator.go
@@ -66,13 +66,7 @@ func (e *RootElevator) PromptIfNecessary(ctx context.Context) error {
 		return nil
 	}
 
-	var prompt string
-
-	if currentUser, _ := utils.GetUsername(); currentUser != "" {
-		prompt = fmt.Sprintf("[%s] password for %s: ", e.Command, currentUser)
-	} else {
-		prompt = fmt.Sprintf("[%s] enter password: ", e.Command)
-	}
+	prompt := fmt.Sprintf("[%s] enter password: ", e.Command)
 
 	_, err := e.PasswordProvider.PromptForPassword(ctx, prompt)
 	return err

--- a/internal/system/fs.go
+++ b/internal/system/fs.go
@@ -7,4 +7,7 @@ type Filesystem interface {
 	ReadLink(path string) (string, error)
 	MkdirAll(path string, perm os.FileMode) error
 	ReadFile(path string) ([]byte, error)
+	CreateFile(path string) error
+	ReadDir(path string) ([]os.FileInfo, error)
+	Glob(pattern string) ([]string, error)
 }

--- a/internal/system/fs.go
+++ b/internal/system/fs.go
@@ -9,5 +9,6 @@ type Filesystem interface {
 	ReadFile(path string) ([]byte, error)
 	CreateFile(path string) error
 	ReadDir(path string) ([]os.FileInfo, error)
+	RealPath(path string) (string, error)
 	Glob(pattern string) ([]string, error)
 }

--- a/internal/system/local_fs.go
+++ b/internal/system/local_fs.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"os"
+	"path/filepath"
 )
 
 type LocalFilesystem struct{}
@@ -20,4 +21,37 @@ func (LocalFilesystem) ReadFile(path string) ([]byte, error) {
 
 func (LocalFilesystem) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
+}
+
+func (LocalFilesystem) CreateFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	_ = f.Close()
+	return nil
+}
+
+func (LocalFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	dirEntries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]os.FileInfo, len(dirEntries))
+	for i, entry := range dirEntries {
+		var info os.FileInfo
+		info, err = entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		entries[i] = info
+	}
+
+	return entries, nil
+}
+
+func (LocalFilesystem) Glob(pattern string) ([]string, error) {
+	return filepath.Glob(pattern)
 }

--- a/internal/system/local_fs.go
+++ b/internal/system/local_fs.go
@@ -52,6 +52,10 @@ func (LocalFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
 	return entries, nil
 }
 
+func (LocalFilesystem) RealPath(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}
+
 func (LocalFilesystem) Glob(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
 }

--- a/internal/system/sftp_fs.go
+++ b/internal/system/sftp_fs.go
@@ -37,3 +37,20 @@ func (f *SFTPFilesystem) ReadFile(path string) ([]byte, error) {
 func (f *SFTPFilesystem) MkdirAll(path string, perm os.FileMode) error {
 	return f.client.MkdirAll(path)
 }
+
+func (f *SFTPFilesystem) CreateFile(path string) error {
+	file, err := f.client.Create(path)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
+}
+
+func (f *SFTPFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	return f.client.ReadDir(path)
+}
+
+func (f *SFTPFilesystem) Glob(pattern string) ([]string, error) {
+	return f.client.Glob(pattern)
+}

--- a/internal/system/sftp_fs.go
+++ b/internal/system/sftp_fs.go
@@ -51,6 +51,10 @@ func (f *SFTPFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
 	return f.client.ReadDir(path)
 }
 
+func (f *SFTPFilesystem) RealPath(path string) (string, error) {
+	return f.client.RealPath(path)
+}
+
 func (f *SFTPFilesystem) Glob(pattern string) ([]string, error) {
 	return f.client.Glob(pattern)
 }

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -505,15 +505,16 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 	}
 
 	var cmdStr string
+
 	if len(cmd.Env) > 0 {
 		var args []string
 		args, err = cmd.BuildShellWrapper()
 		if err != nil {
 			return 0, err
 		}
-		cmdStr = shlex.Join(args)
+		cmdStr = quoteAndJoin(args)
 	} else {
-		cmdStr = shlex.Join(cmd.BuildArgs())
+		cmdStr = quoteAndJoin(cmd.BuildArgs())
 	}
 
 	session.Stdout = cmd.Stdout
@@ -547,6 +548,16 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 	}
 
 	return 0, err
+}
+
+// A minimal args join function that supports passing through
+// multi-line inputs properly to `sh` invocations.
+func quoteAndJoin(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, v := range args {
+		quoted = append(quoted, utils.Quote(v))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func osSignalToSSHSignal(s os.Signal) ssh.Signal {

--- a/internal/systemd/time_test.go
+++ b/internal/systemd/time_test.go
@@ -41,7 +41,8 @@ func TestDurationFromTimeSpan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.span, func(t *testing.T) {
-			actual, err := DurationFromTimeSpan(tt.span)
+			d, err := DurationFromTimeSpan(tt.span)
+			actual := d.Duration()
 
 			if (err != nil) != tt.expectErr {
 				t.Errorf("DurationFromTimeSpan(%q) error = %v, expectErr %v", tt.span, err, tt.expectErr)

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -1,15 +1,37 @@
 {
-  pkgs ? import <nixpkgs> {},
   self ? (import ../flake-compat.nix).outputs,
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${builtins.currentSystem},
+  ...
 }: let
   inherit (pkgs) lib;
 
-  mkTest = test: import test {inherit pkgs self;};
+  mkTest = name: test: let
+    test' = pkgs.testers.runNixOSTest {
+      name = "${name}-test";
+      imports = [
+        test
+        {
+          node.specialArgs = {
+            inherit self;
+          };
+        }
+      ];
+      defaults = {
+        imports = [self.nixosModules.nixos-cli];
+        nixpkgs.overlays = [
+          (_final: _prev: {
+            inherit (self.packages.${pkgs.stdenv.hostPlatform.system}) nixos-cli nixos-cli-legacy;
+          })
+        ];
+      };
+    };
+  in
+    test';
 
   findTests = dir: let
     entries =
       lib.genAttrs' (lib.filesystem.listFilesRecursive dir)
-      (name: lib.nameValuePair (builtins.toString name) (builtins.toString name));
+      (name: lib.nameValuePair (toString name) (toString name));
 
     filenames =
       lib.mapAttrs'
@@ -29,4 +51,4 @@
 
   tests = findTests ./.;
 in
-  lib.mapAttrs (_: test: mkTest test) tests
+  lib.mapAttrs mkTest tests

--- a/nix/tests/example.test.nix
+++ b/nix/tests/example.test.nix
@@ -1,13 +1,8 @@
 {
-  pkgs,
-  self,
-  ...
-}:
-pkgs.testers.runNixOSTest {
-  name = "example-test";
-  nodes.machine1 = _: {
-    imports = [self.nixosModules.nixos-cli];
-    programs.nixos-cli.enable = true;
+  nodes.machine1 = {
+    programs.nixos-cli = {
+      enable = true;
+    };
   };
 
   testScript = ''

--- a/nix/tests/magic-rollback.test.nix
+++ b/nix/tests/magic-rollback.test.nix
@@ -1,0 +1,246 @@
+# This test is mostly copied from nixpkgs,
+# courtesy of `nixos-rebuild-ng`.
+{hostPkgs, ...}: {
+  node.pkgsReadOnly = false;
+
+  nodes = {
+    deployer = {
+      config,
+      lib,
+      pkgs,
+      modulesPath,
+      ...
+    }: let
+      inherit (import ./resources/ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+    in {
+      imports = ["${modulesPath}/profiles/installation-device.nix"];
+
+      # Disable the warning emitted by having multiple password
+      # modes defined for the root user; it is already defined as
+      # empty by the imported installation device module.
+      users.users.root.initialHashedPassword = lib.mkForce null;
+
+      programs.nixos-cli = {
+        enable = true;
+        package = pkgs.nixos-cli-legacy;
+        settings = {
+          ssh = {
+            host_key_verification = "accept-new";
+          };
+          confirmation.always = true;
+          root = {
+            command = "sudo";
+            password_method = "none";
+          };
+        };
+        option-cache.enable = false;
+      };
+
+      system.includeBuildDependencies = true;
+
+      systemd.services.ssh-agent = {
+        description = "SSH key agent";
+        wantedBy = ["default.target"];
+        serviceConfig = {
+          Type = "simple";
+          Environment = [
+            "SSH_AUTH_SOCK=/run/ssh-agent.socket"
+          ];
+          ExecStart = "${config.services.openssh.package}/bin/ssh-agent -D -a $SSH_AUTH_SOCK";
+        };
+      };
+
+      # Define a single socket for the whole test,
+      # since everything runs as root.
+      environment.variables = {
+        SSH_AUTH_SOCK = "/run/ssh-agent.socket";
+      };
+
+      nix.settings = {
+        substituters = lib.mkForce [];
+        hashed-mirrors = null;
+        connect-timeout = 1;
+      };
+
+      virtualisation = {
+        cores = 2;
+        memorySize = 3072;
+      };
+
+      system.build.privateKey = snakeOilPrivateKey;
+      system.build.publicKey = snakeOilPublicKey;
+      system.switch.enable = true;
+    };
+
+    target = {
+      nodes,
+      lib,
+      ...
+    }: let
+      targetConfig = {
+        documentation.enable = false;
+        services.openssh.enable = true;
+
+        users.users.root.openssh.authorizedKeys.keys = [nodes.deployer.system.build.publicKey];
+        users.users.alice.openssh.authorizedKeys.keys = [nodes.deployer.system.build.publicKey];
+        users.users.bob.openssh.authorizedKeys.keys = [nodes.deployer.system.build.publicKey];
+
+        users.users.alice.extraGroups = ["wheel"];
+        users.users.bob.extraGroups = ["wheel"];
+
+        # Disable sudo for root to ensure sudo isn't called without `--sudo`
+        security.sudo.extraRules = lib.mkForce [
+          {
+            groups = ["wheel"];
+            commands = [{command = "ALL";}];
+          }
+          {
+            users = ["alice"];
+            commands = [
+              {
+                command = "ALL";
+                options = ["NOPASSWD"];
+              }
+            ];
+          }
+        ];
+
+        nix.settings.trusted-users = ["@wheel"];
+      };
+    in {
+      config = lib.mkMerge [
+        targetConfig
+        {
+          users.users.alice = {
+            isNormalUser = true;
+            description = "Alice Foobar";
+            password = "foobar";
+            uid = 1000;
+          };
+
+          users.users.bob = {
+            isNormalUser = true;
+            description = "Bob Foobar";
+            password = "foobar";
+          };
+
+          system.build = {
+            inherit targetConfig;
+          };
+          system.switch.enable = true;
+
+          networking.hostName = "target";
+        }
+      ];
+    };
+  };
+
+  testScript = {nodes, ...}: let
+    sshConfig = builtins.toFile "ssh.conf" ''
+      UserKnownHostsFile=/dev/null
+      StrictHostKeyChecking=no
+    '';
+
+    targetConfigJSON = hostPkgs.writeText "target-configuration.json" (
+      builtins.toJSON nodes.target.system.build.targetConfig
+    );
+
+    targetNetworkJSON = hostPkgs.writeText "target-network.json" (
+      builtins.toJSON nodes.target.system.build.networkConfig
+    );
+
+    configFile = hostname: extraConfig:
+      hostPkgs.writeText "configuration.nix" # nix
+      
+      ''
+        { lib, modulesPath, ... }: {
+          imports = [
+            (modulesPath + "/virtualisation/qemu-vm.nix")
+            (modulesPath + "/testing/test-instrumentation.nix")
+            (modulesPath + "/../tests/common/user-account.nix")
+            (lib.modules.importJSON ./target-configuration.json)
+            (lib.modules.importJSON ./target-network.json)
+            ./hardware-configuration.nix
+          ];
+
+          boot.loader.grub = {
+            enable = true;
+            device = "/dev/vda";
+            forceInstall = true;
+          };
+
+          ${extraConfig}
+
+          # this will be asserted
+          networking.hostName = "${hostname}";
+        }
+      '';
+
+    initialConfig = configFile "initial-config" "";
+
+    passwordlessSudoSuccess = configFile "passwordless-sudo" "";
+
+    sshWasDisabled =
+      configFile "ssh-was-disabled" # nix
+      
+      ''
+        services.openssh.enable = lib.mkForce false;
+      '';
+
+    failingActivation =
+      configFile "failing-activation" # nix
+      
+      ''
+        system.activationScripts.failure = {
+          text = "exit 1";
+        };
+      '';
+  in
+    # python
+    ''
+      start_all()
+      target.wait_for_open_port(22)
+
+      deployer.wait_until_succeeds("ping -c1 target")
+      deployer.succeed("install -Dm 600 ${nodes.deployer.system.build.privateKey} /root/.ssh/target_access_key")
+      deployer.succeed("install ${sshConfig} /root/.ssh/config")
+
+      deployer.succeed("ssh-add /root/.ssh/target_access_key")
+
+      target.succeed("nixos-generate-config")
+      deployer.succeed("scp alice@target:/etc/nixos/hardware-configuration.nix /root/hardware-configuration.nix")
+
+      deployer.copy_from_host("${initialConfig}", "/root/initial-config.nix")
+      deployer.copy_from_host("${passwordlessSudoSuccess}", "/root/passwordless-sudo.nix")
+      deployer.copy_from_host("${sshWasDisabled}", "/root/ssh-disabled.nix")
+      deployer.copy_from_host("${failingActivation}", "/root/failing-activation.nix")
+
+      deployer.copy_from_host("${targetNetworkJSON}", "/root/target-network.json")
+      deployer.copy_from_host("${targetConfigJSON}", "/root/target-configuration.json")
+
+      # Ensure sudo is disabled for root
+      target.fail("sudo true")
+
+      with subtest("Deploy to root@target successfully"):
+        deployer.succeed("nixos apply -v -I nixos-config=/root/initial-config.nix --target-host alice@target --remote-root")
+        target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname", timeout=1).rstrip()
+        assert target_hostname == "initial-config", f"{target_hostname=}"
+
+      with subtest("Deploy to alice@target successfully using passwordless sudo"):
+        deployer.succeed("nixos apply -v -I nixos-config=/root/passwordless-sudo.nix --target-host alice@target --remote-root")
+        target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname", timeout=1).rstrip()
+        assert target_hostname == "passwordless-sudo", f"{target_hostname=}"
+
+      with subtest("Attempt to disable SSH should trigger magic rollback"):
+        deployer.fail("nixos apply -v -I nixos-config=/root/ssh-disabled.nix --rollback-timeout=3s --target-host root@target")
+        target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname", timeout=1).rstrip()
+        assert target_hostname == "passwordless-sudo", f"{target_hostname=}"
+
+      with subtest("Failing activation script should trigger magic rollback"):
+        deployer.fail("nixos apply -v -I nixos-config=/root/failing-activation.nix --rollback-timeout=3s --target-host root@target")
+        target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname", timeout=1).rstrip()
+        assert target_hostname == "passwordless-sudo", f"{target_hostname=}"
+
+      # TODO: add concurrent supervisors test failure test?
+    '';
+}

--- a/nix/tests/resources/ssh-keys.nix
+++ b/nix/tests/resources/ssh-keys.nix
@@ -1,0 +1,18 @@
+# Copied from nixpkgs test resources!
+pkgs: {
+  # This key is used in integration tests
+  # This is NOT a security issue
+  # It uses the same key as the one used in OpenSSH fuzz tests
+  # https://github.com/openssh/openssh-portable/blob/V_9_9_P2/regress/misc/fuzz-harness/fixed-keys.h#L76-L85
+  snakeOilPrivateKey = pkgs.writeText "privkey.snakeoil" ''
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACAz0F5hFTFS5nhUcmnyjFVoDw5L/P7kQU8JnBA2rWczAwAAAIhWlP99VpT/
+    fQAAAAtzc2gtZWQyNTUxOQAAACAz0F5hFTFS5nhUcmnyjFVoDw5L/P7kQU8JnBA2rWczAw
+    AAAEDE1rlcMC0s0X3TKVZAOVavZOywwkXw8tO5dLObxaCMEDPQXmEVMVLmeFRyafKMVWgP
+    Dkv8/uRBTwmcEDatZzMDAAAAAAECAwQF
+    -----END OPENSSH PRIVATE KEY-----
+  '';
+
+  snakeOilPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDPQXmEVMVLmeFRyafKMVWgPDkv8/uRBTwmcEDatZzMD snakeoil";
+}


### PR DESCRIPTION
## Description

In case changes in configuration settings for connections (i.e. SSH, internet interfaces, etc.) restart and cause loss of access to the machine in question, this PR implements a magic rollback mechanism that runs on the target.

It offloads a ton of the switch logic into a `supervisor` bash script, which gets ran as a `systemd-run` transient unit on the host. What makes this hugely different from `deploy-rs` is that it does not require modifying the destination closure whatsoever, so magic rollback can be used on systems without `nixos-cli` WHATSOEVER, including on a completely base NixOS system with no extra options.

Closes #119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--rollback-timeout` and `--no-rollback` CLI flags for apply command to control automatic system rollback behavior.
  * Introduced "magic rollback" for remote system deployments via activation supervisor with acknowledgement-based safety.
  * Added new configuration options `rollback.enable` and `rollback.timeout` (replaces `auto_rollback`).

* **Documentation**
  * Updated apply command documentation to describe activation behavior and magic rollback for remote systems.
  * Expanded debug mode environment variable documentation.

* **Tests**
  * Added comprehensive magic rollback test coverage for remote system deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->