### PR TITLE
fix(apply): use correct condition to skip activation

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -235,7 +235,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	} else if opts.BuildImage != "" {
 		buildType = &configuration.ImageBuild{Variant: opts.BuildImage}
 	} else {
-		buildType = &configuration.SystemBuild{Activate: !opts.NoActivate && !opts.NoBoot}
+		buildType = &configuration.SystemBuild{Activate: !opts.NoActivate || !opts.NoBoot}
 	}
 
 	// The local host may need to re-execute as root in order


### PR DESCRIPTION
Testing generations using `nixos apply --no-boot` was skipping activation entirely due to a broken condition.

This resolves that broken condition by only skipping running `switch-to-configuration` if BOTH `--no-activate` and `--no-boot` are specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the system activation logic to trigger correctly under the appropriate flag combinations. Previously, activation required both specific flags to be unset; now it occurs when at least one is not set, providing more flexible control over build behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->