### PR TITLE
feat(settings): add new confirmation settings to control default/invalid input behavior

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -501,9 +501,12 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		log.Errorf("failed to run diff command: %v", err)
 	}
 
-	if !opts.AlwaysConfirm {
+	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		log.Printf("\n")
-		confirm, err := cmdUtils.ConfirmationInput("Activate this configuration?")
+		confirm, err := cmdUtils.ConfirmationInput("Activate this configuration?", cmdUtils.ConfirmationPromptOptions{
+			InvalidBehavior: cfg.Confirmation.Invalid,
+			EmptyBehavior:   cfg.Confirmation.Empty,
+		})
 		if err != nil {
 			log.Errorf("failed to get confirmation: %v", err)
 			return err

--- a/cmd/generation/delete/delete.go
+++ b/cmd/generation/delete/delete.go
@@ -165,8 +165,11 @@ func generationDeleteMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 	log.Printf("\nThere will be %v generations remaining on this machine.", remainingGenCount)
 	log.Print()
 
-	if !opts.AlwaysConfirm {
-		confirm, err := cmdUtils.ConfirmationInput("Proceed?")
+	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
+		confirm, err := cmdUtils.ConfirmationInput("Proceed?", cmdUtils.ConfirmationPromptOptions{
+			InvalidBehavior: cfg.Confirmation.Invalid,
+			EmptyBehavior:   cfg.Confirmation.Empty,
+		})
 		if err != nil {
 			log.Errorf("failed to get confirmation: %v", err)
 			return err

--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -91,9 +91,12 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 		log.Errorf("failed to run diff command: %v", err)
 	}
 
-	if !opts.AlwaysConfirm {
+	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		log.Printf("\n")
-		confirm, err := cmdUtils.ConfirmationInput("Activate the previous generation?")
+		confirm, err := cmdUtils.ConfirmationInput("Activate the previous generation?", cmdUtils.ConfirmationPromptOptions{
+			InvalidBehavior: cfg.Confirmation.Invalid,
+			EmptyBehavior:   cfg.Confirmation.Empty,
+		})
 		if err != nil {
 			log.Errorf("failed to get confirmation: %v", err)
 			return err

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -143,9 +143,12 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 		log.Errorf("failed to run diff command: %v", err)
 	}
 
-	if !opts.AlwaysConfirm {
+	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		log.Printf("\n")
-		confirm, err := cmdUtils.ConfirmationInput("Activate this generation?")
+		confirm, err := cmdUtils.ConfirmationInput("Activate this generation?", cmdUtils.ConfirmationPromptOptions{
+			InvalidBehavior: cfg.Confirmation.Invalid,
+			EmptyBehavior:   cfg.Confirmation.Empty,
+		})
 		if err != nil {
 			log.Errorf("failed to get confirmation: %v", err)
 			return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -164,6 +164,8 @@ func mainCommand() (*cobra.Command, error) {
 }
 
 func Execute() {
+	cobra.EnableTraverseRunHooks = true
+
 	cmd, err := mainCommand()
 	if err != nil {
 		os.Exit(1)

--- a/internal/cmd/utils/confirmation.go
+++ b/internal/cmd/utils/confirmation.go
@@ -1,28 +1,70 @@
 package cmdUtils
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/nix-community/nixos-cli/internal/settings"
 )
 
-func ConfirmationInput(msg string) (bool, error) {
+type ConfirmationPromptOptions struct {
+	InvalidBehavior settings.ConfirmationPromptBehavior
+	EmptyBehavior   settings.ConfirmationPromptBehavior
+}
+
+func ConfirmationInput(msg string, opts ConfirmationPromptOptions) (bool, error) {
 	var input string
+	scanner := bufio.NewScanner(os.Stdin)
 
-	fmt.Fprintf(os.Stderr, "%s\n[y/n]: ", color.GreenString("|> %s", msg))
+	for {
+		fmt.Fprintf(os.Stderr, "%s\n[y/n]: ", color.GreenString("|> %s", msg))
 
-	_, err := fmt.Scanln(&input)
-	if err != nil {
-		return false, err
+		_ = scanner.Scan()
+		input = scanner.Text()
+		if err := scanner.Err(); err != nil {
+			return false, err
+		}
+
+		input = strings.ToLower(strings.TrimSpace(input))
+
+		if len(input) == 0 {
+			switch opts.EmptyBehavior {
+			case settings.ConfirmationPromptRetry:
+				fmt.Fprintln(os.Stderr, "error: input must not be empty")
+				continue
+			case settings.ConfirmationPromptDefaultNo:
+				fmt.Fprintln(os.Stderr, "no input provided; defaulting to no")
+				return false, nil
+			case settings.ConfirmationPromptDefaultYes:
+				fmt.Fprintln(os.Stderr, "no input provided; defaulting to yes")
+				return true, nil
+			default:
+				return false, fmt.Errorf("unhandled EmptyBehavior case: %s", opts.EmptyBehavior)
+			}
+		}
+
+		switch input[0] {
+		case 'y':
+			return true, nil
+		case 'n':
+			return false, nil
+		}
+
+		switch opts.InvalidBehavior {
+		case settings.ConfirmationPromptRetry:
+			fmt.Fprintf(os.Stderr, "error: invalid input '%s'; must be y/n\n", input)
+			continue
+		case settings.ConfirmationPromptDefaultNo:
+			fmt.Fprintf(os.Stderr, "warning: invalid input '%s'; defaulting to no\n", input)
+			return false, nil
+		case settings.ConfirmationPromptDefaultYes:
+			fmt.Fprintf(os.Stderr, "warning: invalid input '%s'; defaulting to yes\n", input)
+			return true, nil
+		default:
+			return false, fmt.Errorf("unhandled InvalidBehavior case: %s", opts.InvalidBehavior)
+		}
 	}
-
-	if len(input) == 0 {
-		return false, err
-	}
-
-	input = strings.ToLower(strings.TrimSpace(input))
-
-	return input[0] == 'y', nil
 }

--- a/internal/settings/completion.go
+++ b/internal/settings/completion.go
@@ -188,16 +188,18 @@ func completeKeys(candidate string) ([]string, cobra.ShellCompDirective) {
 type CompletionValueFunc func(key string, candidate string) ([]string, cobra.ShellCompDirective)
 
 func boolCompletionFunc(key string, candidate string) ([]string, cobra.ShellCompDirective) {
-	options := []string{"true\tTurn this setting on", "false\tTurn this setting off"}
+	return stringCompletionFunc(key, candidate, map[string]string{
+		"true":  "Turn this setting on",
+		"false": "Turn this setting off",
+	})
+}
+
+func stringCompletionFunc(key string, candidate string, candidates map[string]string) ([]string, cobra.ShellCompDirective) {
 	var matches []string
 
-	for _, option := range options {
-		if strings.HasPrefix(option, candidate) {
-			// Yeah, this kind of sucks. It would be preferable to not have to include
-			// the prefix in the arguments, since this becomes rather verbose,
-			// but this works alright, for now.
-
-			match := fmt.Sprintf("%v=%v", key, option)
+	for c, desc := range candidates {
+		if strings.HasPrefix(c, candidate) {
+			match := fmt.Sprintf("%v=%v\t%v", key, c, desc)
 			matches = append(matches, match)
 		}
 	}
@@ -205,8 +207,15 @@ func boolCompletionFunc(key string, candidate string) ([]string, cobra.ShellComp
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
+func completeConfirmationBehaviorKey(key, candidate string) ([]string, cobra.ShellCompDirective) {
+	return stringCompletionFunc(key, candidate, AvailableConfirmationPromptSettings)
+}
+
 // For custom completion functions, use this.
-var completionValueFuncs = map[string]CompletionValueFunc{}
+var completionValueFuncs = map[string]CompletionValueFunc{
+	"confirmation.empty":   completeConfirmationBehaviorKey,
+	"confirmation.invalid": completeConfirmationBehaviorKey,
+}
 
 func completeValues(key string, value string) ([]string, cobra.ShellCompDirective) {
 	cfg := NewSettings()

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -19,6 +19,7 @@ import (
 	shlex "github.com/carapace-sh/carapace-shlex"
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/utils"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
@@ -210,7 +211,13 @@ func wrappedKnownHostsCallback(log logger.Logger, origCallback ssh.HostKeyCallba
 				log.Infof("the authenticity of host '%s' (%s) can't be established", hostname, key.Type())
 				log.Infof("SHA256 fingerprint: %s", fingerprint)
 
-				confirm, err := cmdUtils.ConfirmationInput("Are you sure you want to continue connecting (yes/no)?")
+				confirm, err := cmdUtils.ConfirmationInput("Are you sure you want to continue connecting?", cmdUtils.ConfirmationPromptOptions{
+					// Copy the default SSH behavior of retrying for invalid input.
+					// Disregard user configuration in this case, since this is mimicking
+					// OpenSSH's behavior.
+					InvalidBehavior: settings.ConfirmationPromptRetry,
+					EmptyBehavior:   settings.ConfirmationPromptRetry,
+				})
 				if err != nil {
 					log.Errorf("failed to get confirmation: %v", err)
 					return err


### PR DESCRIPTION
## Description

The confirmation prompt was a bit flaky and didn't respect the `no_confirm` setting, and always defaulted to a response of "no" if no input/invalid input was given.

Since this behavior may not be expected by all users, this PR makes it configurable through some new settings; `confirmation.always` (skip entirely), `confirmation.invalid` (to control what to do when invalid input is given, defaults to retrying), and `confirmation.empty` (to control what to do when no input is given, defaults to treating it as a "no" input, like before).

This also deprecates the `no_confirm` option that was unused anyway, and tells users to use `confirmation.always`. It will be removed in a future release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable confirmation settings to control when prompts are shown and can be skipped.
  * Confirmation prompts now support configurable behaviors for empty or invalid answers (retry, default yes/no) and will re-prompt as configured.
  * Common operations (activate, delete, rollback, switch) and SSH host-key confirmation follow the new confirmation logic.

* **Chores**
  * Enabled traversal of command run hooks during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->