### PR TITLE
feat(option): update optnix dependency

### DIFF
--- a/cmd/option/completion.go
+++ b/cmd/option/completion.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
 	"github.com/spf13/cobra"
-	"github.com/water-sucks/optnix/option"
+	"snare.dev/optnix/option"
 )
 
 func loadOptions(log logger.Logger, cfg *settings.Settings, includes []string) (option.NixosOptionSource, error) {

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -18,8 +18,8 @@ import (
 	"github.com/nix-community/nixos-cli/internal/utils"
 	"github.com/sahilm/fuzzy"
 	"github.com/spf13/cobra"
-	"github.com/water-sucks/optnix/option"
-	optionTUI "github.com/water-sucks/optnix/tui"
+	"snare.dev/optnix/option"
+	optionTUI "snare.dev/optnix/tui"
 	"github.com/yarlson/pin"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,11 @@ require (
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
-	github.com/water-sucks/optnix v0.3.0
 	github.com/yarlson/pin v0.9.1
 	golang.org/x/crypto v0.44.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
+	snare.dev/optnix v0.3.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/water-sucks/go-systemd/v22 v22.0.0-20251014195852-fe9dbfc225a6 h1:1N6u0lE8rHRCspDB9O96quNmGnmvNN8xH5gDbWHCeLQ=
 github.com/water-sucks/go-systemd/v22 v22.0.0-20251014195852-fe9dbfc225a6/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
-github.com/water-sucks/optnix v0.3.0 h1:iClGJuiW8E0lVx2OzlX0H+J3j9Xye8ruhNFQfZ7DIA8=
-github.com/water-sucks/optnix v0.3.0/go.mod h1:8Dek90iolwyNqiiPZdETZKQvA3JacuWtbiUxdGT1e6E=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
@@ -250,3 +248,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+snare.dev/optnix v0.3.1 h1:W5mlqubazK2SyvPObE7vk10tkNDklccniFnDyQf4kX8=
+snare.dev/optnix v0.3.1/go.mod h1:GyNC5EYxp5EKxMP2wNXWZx0LgYuqAQP17jUj8pRRz+g=

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
     ];
   };
 
-  vendorHash = "sha256-JjCXGy/ysZajWSZP2Ap90iSbyQaIifa+l16x7215d+c=";
+  vendorHash = "sha256-9kxY6VE2bRTncyh8KHhlmCW6w2AqxKjaKWY3yXiAdVQ=";
 
   nativeBuildInputs = [installShellFiles scdoc];
 


### PR DESCRIPTION
This PR updates `optnix` to v0.3.1.

v0.3.1 renames the module to `snare.dev/optnix` and adds a regex search mode to the TUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the upstream source for a core dependency (no functional or API changes).
  * Updated package checksum used by the build system to ensure reproducible builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->