### PR TITLE
docs: use optnix instead of nix-options-doc to generate module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ with the following Makefile rules:
 
 - Documentation for all available settings in `config.toml`
 - Module documentation for `services.nixos-cli`, built using
-  [`nix-options-doc`](https://github.com/Thunderbottom/nix-options-doc)
+  [`optnix`](https://github.com/water-sucks/optnix)
 
 The rest of the site documentation files are located in [doc/man](./doc/src).
 

--- a/doc/options.nix
+++ b/doc/options.nix
@@ -1,0 +1,20 @@
+{pkgs ? import <nixpkgs> {}}: let
+  self = (import ../nix/flake-compat.nix).outputs;
+
+  inherit (self.inputs) nixpkgs;
+
+  nixosModules = import "${nixpkgs}/nixos/modules/module-list.nix";
+
+  optnixLib = self.inputs.optnix.mkLib pkgs;
+in
+  optnixLib.mkOptionsListFromModules {
+    modules =
+      nixosModules
+      ++ [
+        self.nixosModules.nixos-cli
+      ];
+    specialArgs = {
+      inherit pkgs;
+    };
+    excluded = ["_module.args"];
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -34,57 +50,18 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nix-options-doc": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1742115705,
-        "narHash": "sha256-RfXwJPWBoWswIU68+y/XZfTWtFHd/fK14bKvOlRmfPo=",
-        "owner": "Thunderbottom",
-        "repo": "nix-options-doc",
-        "rev": "2caa4b5756a8666d65d70122f413e295f56886e7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Thunderbottom",
-        "ref": "v0.2.0",
-        "repo": "nix-options-doc",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740695751,
-        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
-        "owner": "nixos",
+        "lastModified": 1764527385,
+        "narHash": "sha256-nA5ywiGKl76atrbdZ5Aucd8SjF/v8ew9b9QsC+MKL14=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
+        "rev": "23258e03aaa49b3a68597e3e50eb0cbce7e42e9d",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -106,11 +83,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1764527385,
-        "narHash": "sha256-nA5ywiGKl76atrbdZ5Aucd8SjF/v8ew9b9QsC+MKL14=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23258e03aaa49b3a68597e3e50eb0cbce7e42e9d",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -120,48 +97,31 @@
         "type": "github"
       }
     },
+    "optnix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1765418479,
+        "narHash": "sha256-33VCCXiEnEL9N2wVxo9FHLwL8KWH6qk+MNRcSThOPWs=",
+        "owner": "water-sucks",
+        "repo": "optnix",
+        "rev": "01facc3de860bf479723bf19535586564e59fe73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "water-sucks",
+        "repo": "optnix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "nix-options-doc": "nix-options-doc",
-        "nixpkgs": "nixpkgs_2"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-options-doc",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1740796337,
-        "narHash": "sha256-FuoXrXZPoJEZQ3PF7t85tEpfBVID9JQIOnVKMNfTAb0=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "bbac9527bc6b28b6330b13043d0e76eac11720dc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs",
+        "optnix": "optnix"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
-    nix-options-doc.url = "github:Thunderbottom/nix-options-doc/v0.2.0";
+    optnix.url = "github:water-sucks/optnix";
   };
 
   outputs = {
@@ -31,7 +31,6 @@
       perSystem = {
         self',
         pkgs,
-        system,
         ...
       }: {
         packages = {
@@ -47,8 +46,6 @@
         devShells = let
           inherit (pkgs) go golangci-lint mkShell mdbook scdoc;
           inherit (pkgs.nodePackages) prettier;
-
-          nix-options-doc = inputs.nix-options-doc.packages.${system}.default;
         in {
           default = mkShell {
             name = "nixos-shell";
@@ -59,7 +56,6 @@
               mdbook
               prettier
               scdoc
-              nix-options-doc
             ];
           };
         };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -71,6 +71,7 @@ in {
       default = lib.maybeEnv "NIXOS_GENERATION_TAG" null;
       description = "A description for this generation";
       example = "Sign Git GPG commits by default";
+      internal = true;
     };
 
     prebuildOptionCache = lib.mkOption {


### PR DESCRIPTION
## Description

`nix-options-doc` has to be built from source all the time, which slows down CI. This brings in `optnix` to do this functionality instead. 

A little information is lost, such as line numbers and references to other values (their actual values by default are substituted).

We are already using `optnix` as a dependency for the binary, so including the flake input isn't too bad. The flake input is solely for the optnix docgen library, and this can theoretically be removed later to only use nixpkgs stdlib functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Switched module documentation to use optnix and introduced a new per-option Markdown generation flow for module docs.
  * Added generated module options to the docs output.

* **Chores**
  * Replaced prior docs tooling with optnix and removed the old docs tooling from the build/dev setup.

* **Other**
  * Marked the generationTag option as internal (affects its public visibility).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->