### PR TITLE
feat(completion): Add path completion

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -90,6 +90,7 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 
 			return nil
 		},
+		ValidArgsFunction: cmdUtils.FlakeOrNixFileCompletions,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			log := logger.FromContext(ctx)

--- a/cmd/enter/enter.go
+++ b/cmd/enter/enter.go
@@ -44,6 +44,9 @@ func EnterCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.Silent, "silent", "s", false, "Suppress all system activation output")
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Show verbose logging")
 
+	_ = cmd.RegisterFlagCompletionFunc("root", cmdUtils.DirCompletions)
+	_ = cmd.RegisterFlagCompletionFunc("system", cmdUtils.DirCompletions)
+
 	cmd.MarkFlagsMutuallyExclusive("silent", "verbose")
 
 	cmdUtils.SetHelpFlagText(&cmd)

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -35,5 +35,8 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Root, "root", "r", "/", "Treat `path` as the root directory")
 	cmd.Flags().BoolVarP(&opts.ShowHardwareConfig, "show-hardware-config", "s", false, "Print hardware config to stdout and exit")
 
+	_ = cmd.RegisterFlagCompletionFunc("dir", cmdUtils.DirCompletions)
+	_ = cmd.RegisterFlagCompletionFunc("root", cmdUtils.DirCompletions)
+
 	return &cmd
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -80,6 +80,7 @@ func InstallCommand() *cobra.Command {
 
 			return nil
 		},
+		ValidArgsFunction: cmdUtils.FlakeOrNixFileCompletions,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			log := logger.FromContext(ctx)
@@ -131,6 +132,10 @@ func InstallCommand() *cobra.Command {
 		nixopts.AddUpdateInputNixOption(&cmd, &opts.NixOptions.UpdateInputs)
 		nixopts.AddOverrideInputNixOption(&cmd, &opts.NixOptions.OverrideInputs)
 	}
+
+	_ = cmd.RegisterFlagCompletionFunc("channel", cmdUtils.DirCompletions)
+	_ = cmd.RegisterFlagCompletionFunc("root", cmdUtils.DirCompletions)
+	_ = cmd.RegisterFlagCompletionFunc("system", cmdUtils.DirCompletions)
 
 	cmd.MarkFlagsMutuallyExclusive("channel", "no-channel-copy")
 

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -72,9 +72,13 @@ func OptionCommand() *cobra.Command {
 
 	if build.Flake() {
 		cmd.Flags().StringVarP(&opts.FlakeRef, "flake", "f", "", "Flake `ref` to explicitly load options from")
+
+		_ = cmd.RegisterFlagCompletionFunc("flake", cmdUtils.DirCompletions)
 	} else {
 		cmd.Flags().StringVar(&opts.File, "file", "", "File `path` to load NixOS configuration from")
 		cmd.Flags().StringVar(&opts.Attr, "attr", "", "Attribute `path` inside of file pointing to configuration")
+
+		_ = cmd.RegisterFlagCompletionFunc("file", cmdUtils.FileCompletions("nix"))
 	}
 
 	nixopts.AddIncludesNixOption(&cmd, &opts.NixPathIncludes)

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -58,6 +58,7 @@ func ReplCommand() *cobra.Command {
 
 			return nil
 		},
+		ValidArgsFunction: cmdUtils.FlakeOrNixFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdUtils.CommandErrorHandler(replMain(cmd, &opts))
 		},

--- a/internal/cmd/utils/completion.go
+++ b/internal/cmd/utils/completion.go
@@ -3,9 +3,11 @@ package cmdUtils
 import (
 	"os"
 
+	"github.com/nix-community/nixos-cli/internal/build"
 	"github.com/nix-community/nixos-cli/internal/constants"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
+	"github.com/spf13/cobra"
 )
 
 // Prepare command resources that are needed for completion, but that
@@ -31,4 +33,29 @@ func PrepareCompletionResources() (logger.Logger, *settings.Settings) {
 	}
 
 	return log, cfg
+}
+
+func FlakeOrNixFileCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	if build.Flake() {
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	} else {
+		return []string{"nix"}, cobra.ShellCompDirectiveFilterFileExt
+	}
+}
+
+func DirCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveFilterDirs
+}
+
+func FileCompletions(extensions ...string) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(extensions) != 0 {
+			return extensions, cobra.ShellCompDirectiveFilterFileExt
+		} else {
+			return nil, cobra.ShellCompDirectiveDefault
+		}
+	}
 }


### PR DESCRIPTION
This adds:
 - path completion to the first positional parameter of  `apply`, `install` and `repl` 
   - directory completion in flake builds (`[FLAKE-REF]`)
   - file completion in legacy builds (`[FILE]`)
 - directory completion to:
   - enter: 
     - `--root`, `--system`
   - install: 
     - `--channel`, `--root`, `--system`
   - init:
     - `--dir`, `--root`
   - option:
     - `--flake`
 - file completion to:
   - option:
     - `--file`