### PR TITLE
fix(enter): inherit parent PID namespace

### DIFF
--- a/cmd/enter/run.go
+++ b/cmd/enter/run.go
@@ -164,7 +164,7 @@ const NIXOS_REEXEC = "_NIXOS_ENTER_REEXEC"
 func execSandboxedEnterProcess(log logger.Logger) error {
 	log.Debugf("sandboxing process with unshare")
 
-	argv := []string{"unshare", "--fork", "--mount", "--uts", "--mount-proc", "--pid"}
+	argv := []string{"unshare", "--fork", "--mount", "--uts", "--mount-proc"}
 	argv = append(argv, os.Args...)
 
 	// Map root user if not running as root


### PR DESCRIPTION
Original commit: NixOS/nixpkgs@798aa80

This is to stop systemd detecting the chroot as a container, and thus inhibiting `bootctl` from populating EFI variables.

It can be tested with `nixos enter -c systemd-detect-virt`, which outputs `kvm` with the fix, and `container-other` without it.