### PR TITLE
fix(enter): Fix running systemd tmpfiles with no users or groups

### DIFF
--- a/cmd/enter/run.go
+++ b/cmd/enter/run.go
@@ -248,15 +248,11 @@ func activate(s system.CommandRunner, root string, systemClosure string, silent 
 
 	// Create a tmpfs for building/activating the NixOS system.
 	systemdTmpfiles := filepath.Join(systemClosure, "sw", "bin", "systemd-tmpfiles")
-	argv = []string{"chroot", root, systemdTmpfiles, "--create", "--remove", "-E"}
+	argv = []string{"chroot", root, systemdTmpfiles, "--create", "--remove", "--graceful", "-E"}
 
 	s.Logger().CmdArray(argv)
 
 	tmpfilesCmd := system.NewCommand(argv[0], argv[1:]...)
-
-	// Hide the unhelpful "failed to replace specifiers" errors caused by missing /etc/machine-id.
-	tmpfilesCmd.Stdout = nil
-	tmpfilesCmd.Stderr = nil
 
 	_, err = s.Run(tmpfilesCmd)
 	return err


### PR DESCRIPTION
When a system configuration has `userborn` or `sysusers` enabled, the activation script does not create users or groups.
This causes the `systemd-tmpfiles` command in `nixos enter` to fail, due to configuration lines with unknown users or groups . In the original `nixos-enter`, errors from `systemd-tmpfiles` are [ignored](https://github.com/NixOS/nixpkgs/blob/1986a0d98b8ee2e94f4ec49c5a94edc765cc93d4/pkgs/by-name/ni/nixos-enter/nixos-enter.sh#L108). But if we add the `--graceful` flag, then `systemd-tmpfiles` will itself ignore unknown users or groups and exit successfully. Also, the original reason for ignoring the errors, the "failed to replace specifiers" error, does not seem to ever trigger. So I think we can stop silencing the `systemd-tmpfiles` command as well.