### PR TITLE
feat(apply): Don't re-exec as root by default and add a flag for escalating to root locally

### DIFF
--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -179,6 +179,17 @@ global *--config* flag as such:
 
 	Default: *system*
 
+*--local-root*
+	Prefix local activation and channel upgrade commands with an escalation command like _sudo_.
+
+	Only applies for local hosts.
+
+	This is applicable to switching the active Nix profile, running
+	the _switch-to-configuration_ script, and upgrading the root users
+	Nix channels.
+
+	The escalation command used is defined by the setting _root_command_.
+
 *--remote-root*
 	Prefix remote activation commands with an escalation command like _sudo_.
 
@@ -188,7 +199,7 @@ global *--config* flag as such:
 	the _switch-to-configuration_ script, so users may need to type in a
 	password twice if NOPASSWD is not set for that user.
 
-	This is defined by the setting _root_command_.
+	The escalation command used is defined by the setting _root_command_.
 
 *-s*, *--specialisation* <NAME>
 	Activate a specialisation *NAME* from the available specialisations.

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -36,6 +36,7 @@ type ApplyOpts struct {
 	NoBoot                bool
 	OutputPath            string
 	ProfileName           string
+	LocalRoot             bool
 	RemoteRoot            bool
 	Specialisation        string
 	TargetHost            string

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -34,6 +34,7 @@ type ApplySettings struct {
 	UseNom                bool   `koanf:"use_nom"`
 	UseGitCommitMsg       bool   `koanf:"use_git_commit_msg"`
 	IgnoreDirtyTree       bool   `koanf:"ignore_dirty_tree"`
+	ReexecRoot            bool   `koanf:"reexec_as_root"`
 }
 
 type ConfirmationSettings struct {
@@ -127,6 +128,11 @@ var SettingsDocs = map[string]DescriptionEntry{
 	"apply.ignore_dirty_tree": {
 		Short: "Ignore dirty working tree when using Git commit message for --tag",
 		Long:  "Allows 'apply' to use Git commit messages even when the working directory is dirty.",
+	},
+	"apply.reexec_as_root": {
+		Short: "Re-execute process as root using `root_command`",
+		Long: "Re-execute process as root using `root_command`. Only applies when activating or creating boot entries on a local system," +
+			" or upgrading the root user's Nix channels.",
 	},
 	"auto_rollback": {
 		Short: "Automatically rollback profile on activation failure",


### PR DESCRIPTION
The new option `--local-root` provides behaviour equal to that of `nixos-rebuild --sudo`
by escalating certain operations as necessary:
 - Channel upgrades
 - Local Nix profile modifications
 - Local switch-to-configuration runs

By not re-executing by default we avoid bypassing a non-root user's eval cache
when running `nixos apply` after having already built the configuration.

The previous behaviour can be enabled with the new setting `apply.reexec_as_root`.

Additionally, channel upgrades now always run as root (see NixOS/nixpkgs@028893d7)