### PR TITLE
fix(apply): Fix dry builds

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -66,8 +66,8 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 					return fmt.Errorf("--install-bootloader requires activation, remove --no-activate and/or --no-boot to use this option")
 				}
 
-				if opts.OutputPath == "" {
-					return fmt.Errorf("if --no-activate and --no-boot are both specified, --output must be specified too")
+				if opts.OutputPath == "" && !opts.Dry {
+					return fmt.Errorf("if --no-activate and --no-boot are both specified, one of --output or --dry must also be specified")
 				}
 			}
 

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -72,7 +72,7 @@ _nixos-rebuild dry-activate_
 
 _nixos-rebuild dry-build_
 
-	*nixos apply --dry --no-activate --no-boot --output ./result*
+	*nixos apply --dry --no-activate --no-boot*
 
 Many other behaviors for _nixos-rebuild_ are in the *nixos generation*
 command tree. See *nixos-cli-generation(1)* for details.
@@ -146,8 +146,8 @@ global *--config* flag as such:
 	a real configuration to be built beforehand.
 
 	Dry builds of the configuration can be achieved by passing *--no-activate*
-	and *--no-boot*, as well as *--output*. If any of these options are not
-	passed, then dry activation is assumed.
+	and *--no-boot*. If any of these options are not passed, then dry activation
+	is assumed.
 
 	The list of changes is not guaranteed to be complete for dry activations.
 


### PR DESCRIPTION
The man page states that the dry-build alias is `nixos apply --dry --no-activate --no-boot --output ./result`, but this does not work as `--dry` and `--output` are mutually exclusive flags.

Removing `--output` then triggers a validation error, since the code currently requires `--output` when both `--no-activate` and `--no-boot` are set, which are themselves required for a dry build.

This change updates the logic to allow either `--output` or `--dry` in this case, and adjusts the man page to use the correct alias.