### PR TITLE
fix(apply): validate system closure

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,4 +7,5 @@ const (
 	CurrentSystem             = "/run/current-system"
 	NixOSMarker               = "/etc/NIXOS"
 	NixChannelDirectory       = NixProfileDirectory + "/per-user/root/channels"
+	NixOSVersionFile          = "nixos-version"
 )

--- a/internal/generation/generation.go
+++ b/internal/generation/generation.go
@@ -93,7 +93,7 @@ func GenerationFromDirectory(generationDirname string, number uint64) (*Generati
 	// Fall back to reading the nixos-version file that should always
 	// exist if the `nixos-version.json` file doesn't exist.
 	if info.NixosVersion == "" {
-		nixosVersionFile := filepath.Join(generationDirname, "nixos-version")
+		nixosVersionFile := filepath.Join(generationDirname, constants.NixOSVersionFile)
 		nixosVersionContents, err := os.ReadFile(nixosVersionFile)
 		if err != nil {
 			encounteredErrors = append(encounteredErrors, err)


### PR DESCRIPTION
This tests for the existence of the `nixos-version` file in the system closure before setting the new system profile.

This is needed because of a nix bug (NixOS/nix#13367) that means that running `nixos apply` with a `path:` or `git+file:` flake URL and the current working directory set to a store path (or symlink to a store path) leads to said store path as the built system closure.

 (See NixOS/nixpkgs@ae48ab38 and NixOS/nixpkgs@0f6624e2)