### PR TITLE
fix(ssh): parse ssh host string manually, clean up bugs

### DIFF
--- a/internal/ssh/host.go
+++ b/internal/ssh/host.go
@@ -1,0 +1,108 @@
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+type UserHostPort struct {
+	User string
+	Host string
+	Port int
+}
+
+func ParseUserHostPort(s string) (*UserHostPort, error) {
+	var user string
+	if at := strings.LastIndex(s, "@"); at != -1 {
+		user = s[:at]
+		s = s[at+1:]
+	}
+
+	// First, check if [] is a closed pair.
+	// If it is, then we can enforce an IPV6 address
+	// and parse it on our own.
+	// If any brackets are unmatched or if there
+	// are multiple, then error out.
+	// The port must also be valid here.
+	// Bracketed IPv6 handling
+	if strings.ContainsAny(s, "[]") {
+		// Must be exactly one opening and one closing bracket
+		if strings.Count(s, "[") != 1 || strings.Count(s, "]") != 1 {
+			return nil, fmt.Errorf("invalid IPv6 address format; mismatched or multiple brackets detected")
+		}
+
+		// Must start with '['
+		if !strings.HasPrefix(s, "[") {
+			return nil, fmt.Errorf("invalid IPv6 address format; missing [")
+		}
+
+		end := strings.Index(s, "]")
+		if end == -1 {
+			return nil, fmt.Errorf("invalid IPv6 address format; missing ]")
+		}
+
+		hostPart := s[1:end]
+		rest := s[end+1:]
+
+		// Optional port
+		var port int
+		if rest != "" {
+			if !strings.HasPrefix(rest, ":") {
+				return nil, fmt.Errorf("invalid host format")
+			}
+
+			p, err := parsePort(rest[1:])
+			if err != nil {
+				return nil, err
+			}
+			port = p
+		}
+
+		return &UserHostPort{
+			User: user,
+			Host: hostPart,
+			Port: port,
+		}, nil
+	}
+
+	// Everything else that does not follow this rule,
+	// so attempt to parse it as a hostname:port pair.
+	var host, portStr string
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		host = s
+	}
+
+	var port int
+	if portStr != "" {
+		p, err := parsePort(portStr)
+		if err != nil {
+			return nil, err
+		}
+
+		port = p
+	}
+
+	ret := &UserHostPort{
+		User: user,
+		Host: host,
+		Port: port,
+	}
+	return ret, nil
+}
+
+func parsePort(input string) (int, error) {
+	p, err := strconv.ParseUint(input, 10, 16)
+	if err != nil {
+		return 0, errors.New("port must be between 1-65535")
+	}
+
+	if p == 0 || p > 65535 {
+		return 0, errors.New("port must be between 1-65535")
+	}
+
+	return int(p), nil
+}

--- a/internal/ssh/host_test.go
+++ b/internal/ssh/host_test.go
@@ -1,0 +1,136 @@
+package ssh_test
+
+import (
+	"testing"
+
+	sshUtils "github.com/nix-community/nixos-cli/internal/ssh"
+)
+
+func TestParseUserHostPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *sshUtils.UserHostPort
+		wantErr bool
+	}{
+		{
+			name:  "host only",
+			input: "example.com",
+			want: &sshUtils.UserHostPort{
+				User: "",
+				Host: "example.com",
+				Port: 0,
+			},
+		},
+		{
+			name:  "host and port",
+			input: "example.com:22",
+			want: &sshUtils.UserHostPort{
+				User: "",
+				Host: "example.com",
+				Port: 22,
+			},
+		},
+		{
+			name:  "user host and port",
+			input: "alice@example.com:2222",
+			want: &sshUtils.UserHostPort{
+				User: "alice",
+				Host: "example.com",
+				Port: 2222,
+			},
+		},
+		{
+			name:  "ipv4 and port",
+			input: "192.168.1.10:22",
+			want: &sshUtils.UserHostPort{
+				User: "",
+				Host: "192.168.1.10",
+				Port: 22,
+			},
+		},
+		{
+			name:  "bracketed ipv6 without port",
+			input: "[2001:db8::1]",
+			want: &sshUtils.UserHostPort{
+				User: "",
+				Host: "2001:db8::1",
+				Port: 0,
+			},
+		},
+		{
+			name:  "bracketed ipv6 with port",
+			input: "[2001:db8::1]:22",
+			want: &sshUtils.UserHostPort{
+				User: "",
+				Host: "2001:db8::1",
+				Port: 22,
+			},
+		},
+		{
+			name:  "user and bracketed ipv6 with port",
+			input: "bob@[2001:db8::1]:2222",
+			want: &sshUtils.UserHostPort{
+				User: "bob",
+				Host: "2001:db8::1",
+				Port: 2222,
+			},
+		},
+		{
+			name:    "invalid port",
+			input:   "example.com:99999",
+			wantErr: true,
+		},
+		{
+			name:    "non numeric port",
+			input:   "example.com:http",
+			wantErr: true,
+		},
+		{
+			name:  "unbracketed ipv6 without port",
+			input: "2001:db8::1",
+			want: &sshUtils.UserHostPort{
+				User: "",
+				Host: "2001:db8::1",
+				Port: 0,
+			},
+		},
+		{
+			name:    "invalid bracketed ipv6 missing closing bracket",
+			input:   "[2001:db8::1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid bracketed ipv6 junk after bracket",
+			input:   "[2001:db8::1]junk",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sshUtils.ParseUserHostPort(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.User != tt.want.User {
+				t.Errorf("User: got %q, want %q", got.User, tt.want.User)
+			}
+			if got.Host != tt.want.Host {
+				t.Errorf("Host: got %q, want %q", got.Host, tt.want.Host)
+			}
+			if got.Port != tt.want.Port {
+				t.Errorf("Port: got %d, want %d", got.Port, tt.want.Port)
+			}
+		})
+	}
+}

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	shlex "github.com/carapace-sh/carapace-shlex"
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
@@ -77,7 +78,8 @@ func NewSSHSystem(host string, log logger.Logger) (*SSHSystem, error) {
 
 	var conn net.Conn
 	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
-		conn, err = net.Dial("unix", sock)
+		dialer := net.Dialer{Timeout: 2 * time.Second}
+		conn, err = dialer.Dial("unix", sock)
 		if err == nil {
 			agentClient := agent.NewClient(conn)
 			auth = append(auth, ssh.PublicKeysCallback(agentClient.Signers))

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -412,9 +412,10 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 
 	go func() {
 		for sig := range sigCh {
-			s := osSignalToSSHSignal(sig)
-			if err := session.Signal(s); err != nil {
-				log.Warnf("failed to forward signal '%v': %v", s, err)
+			if s := osSignalToSSHSignal(sig); s != "" {
+				if err := session.Signal(s); err != nil {
+					log.Warnf("failed to forward signal '%v': %v", s, err)
+				}
 			}
 		}
 	}()

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -385,7 +385,6 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 			// seems to have a bug where the first attempt is wrong due to
 			// the PTY discarding the first inputted byte.
 			restoreLocal, err := requestRootPasswordPTY(session, cmd.Stdin)
-
 			if err != nil {
 				log.Warnf("unable to make local terminal raw: %v", err)
 			} else {
@@ -466,7 +465,11 @@ func osSignalToSSHSignal(s os.Signal) ssh.Signal {
 }
 
 func requestRootPasswordPTY(session *ssh.Session, stdin io.Reader) (func(), error) {
-	file := stdin.(*os.File)
+	file, ok := stdin.(*os.File)
+	if !ok {
+		return nil, errors.New("stdin is not a file")
+	}
+
 	w, h, err := term.GetSize(int(file.Fd()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get terminal size: %w", err)


### PR DESCRIPTION
SSH host strings are not URLs. The previous code treated them as such, and this failed in the case of link-local IPV6 addresses that are bracketed and have percent signs.

This PR adds a small `user@host:port` parser that behaves similarly to OpenSSH to correct this behavior, and other future SSH vs. URL disparities.

It also fixes some small bugs with the SSH command system.

Closes #146.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced SSH connection parsing to better support IPv6 and IPv4 addresses with improved port detection
- Improved error handling and logging for SSH agent connection failures
- Added validation for signal forwarding during remote SSH sessions
- Strengthened input validation for password authentication operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->