### PR TITLE
chore: control coderabbit verbosity

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+language: 'en-US'
+early_access: false
+reviews:
+  high_level_summary: true
+  poem: false
+  review_status: false
+  changed_files_summary: true
+  sequence_diagrams: false
+  assess_linked_issues: true
+  path_filters:
+    - '!**/*.lock'
+    - '!go.mod'
+    - '!go.sum'
+  auto_review:
+    enabled: false
+    drafts: false
+chat:
+  auto_reply: true


### PR DESCRIPTION
CodeRabbit is being a bit verbose, so this PR controls its output verbosity somewhat and disables the status message for linked PRs, since that can get rather annoying.