### PR TITLE
fix(activate); correct compile errors on unsupported platforms

### DIFF
--- a/cmd/activate/activate.go
+++ b/cmd/activate/activate.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	NIXOS_STC_PARENT_EXE = "__NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE"
+)
+
 func ActivateCommand() *cobra.Command {
 	var opts cmdOpts.ActivateOpts
 

--- a/cmd/activate/run.go
+++ b/cmd/activate/run.go
@@ -39,8 +39,6 @@ const (
 	RELOAD_BY_ACTIVATION_LIST_FILE      = "/run/nixos/activation-reload-list"
 	RESTART_BY_ACTIVATION_LIST_FILE     = "/run/nixos/activation-restart-list"
 
-	NIXOS_STC_PARENT_EXE = "__NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE"
-
 	SYSINIT_REACTIVATION_TARGET = "sysinit-reactivation.target"
 )
 

--- a/cmd/activate/unsupported.go
+++ b/cmd/activate/unsupported.go
@@ -5,12 +5,12 @@ package activate
 import (
 	"fmt"
 
-	"github.com/nix-community/nixos-cli/internal/activation"
+	cmdOpts "github.com/nix-community/nixos-cli/internal/cmd/opts"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/spf13/cobra"
 )
 
-func activateMain(cmd *cobra.Command, _ activation.SwitchToConfigurationAction) error {
+func activateMain(cmd *cobra.Command, _ *cmdOpts.ActivateOpts) error {
 	log := logger.FromContext(cmd.Context())
 	err := fmt.Errorf("the activate command is unsupported on non-NixOS systems")
 	log.Error(err)


### PR DESCRIPTION
Self-explanatory. Fixes errors with `nixos activate` main function signatures being out of date on non-Linux platforms, because I want to be able to deploy NixOS systems from macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal activation code structure for improved maintainability.
  * Enhanced error handling in the activation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->