### PR TITLE
fix: Support quoted attribute names

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/constants"
 	"github.com/nix-community/nixos-cli/internal/generation"
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/nix"
 	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
 	"github.com/nix-community/nixos-cli/internal/utils"
@@ -769,7 +770,7 @@ func getAvailableImageAttrs(
 	case *configuration.FlakeRef:
 		evalArgs := nixopts.NixOptionsToArgsListByCategory(cobraCmd.Flags(), nixOpts, "lock")
 
-		attr = fmt.Sprintf("%s#nixosConfigurations.%s.config.system.build.images", v.URI, v.System)
+		attr = v.BuildAttr("images")
 		argv = []string{"nix", "eval", "--json", attr, "--apply", "builtins.attrNames"}
 		argv = append(argv, evalArgs...)
 	case *configuration.LegacyConfiguration:
@@ -814,11 +815,12 @@ func getImageName(
 	var argv []string
 	var attr string
 
+	imgName = nix.MakeAttrName(imgName)
 	switch v := cfg.(type) {
 	case *configuration.FlakeRef:
 		evalArgs := nixopts.NixOptionsToArgsListByCategory(cobraCmd.Flags(), nixOpts, "lock")
 
-		attr = fmt.Sprintf("%s#nixosConfigurations.%s.config.system.build.images.%s.passthru.filePath", v.URI, v.System, imgName)
+		attr = v.BuildAttr("images", imgName, "passthru", "filePath")
 		argv = []string{"nix", "eval", "--raw", attr}
 		argv = append(argv, evalArgs...)
 	case *configuration.LegacyConfiguration:

--- a/doc/man/nixos-cli.1.scd
+++ b/doc/man/nixos-cli.1.scd
@@ -75,6 +75,14 @@ nixos-cli - a tool for managing NixOS installations
 *--version*
 	Display the version of the *nixos-cli* tool.
 
+# ARGUMENTS
+
+Nix attribute arguments containing special characters are interpreted as follows:
+
+- *Spaces*: Attribute names with spaces must be enclosed in quotes. For example: "my flake host".
+- *Dots*: Dots (.) are treated as separators in attribute paths. To include a literal dot as part of an attribute name, escape it with a backslash (\\.). For example, the argument "path.to\\..config" is interpreted as the attribute path: [ "path" "to." "config" ]. A literal backslash can be included by escaping it with another backslash (\\\\). The number of backslashes required depends on how the argument is quoted (unquoted, single-quoted, or double-quoted), since your shell may consume some escapes before _nixos-cli_ sees them. For example, when the path is not quoted, two backslashes are required to produce a single literal backslash. Consult your shell’s manual for details on its escaping rules.
+- *Double Quotation Marks*: Double quotation marks (") cannot be part of attribute names, even when escaped. For example, the following will not work: 'my flake \\"host'. This is a limitation of the underlying _nix_ command that _nixos-cli_ depends on.
+
 # AUTHORS
 
 Maintained by Varun Narravula <varun@snare.dev>. Up-to-date sources can be

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nix-community/nixos-cli/internal/build"
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/nix"
 	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
 	"github.com/spf13/pflag"
@@ -97,5 +98,5 @@ type ImageBuild struct {
 }
 
 func (i *ImageBuild) BuildAttr() string {
-	return fmt.Sprintf("images.%s", i.Variant)
+	return nix.MakeAttrPath("images", nix.MakeAttrName(i.Variant))
 }

--- a/internal/generation/specialisations.go
+++ b/internal/generation/specialisations.go
@@ -2,7 +2,6 @@ package generation
 
 import (
 	"encoding/json"
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -37,7 +36,7 @@ func CollectSpecialisationsFromConfig(cfg configuration.Configuration) []string 
 
 	switch c := cfg.(type) {
 	case *configuration.FlakeRef:
-		attr := fmt.Sprintf("%s#nixosConfigurations.%s.config.specialisation", c.URI, c.System)
+		attr := c.ConfigAttr("specialisation")
 		argv = []string{"nix", "eval", attr, "--apply", "builtins.attrNames", "--json"}
 	case *configuration.LegacyConfiguration:
 		argv = []string{

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -1,0 +1,77 @@
+package nix
+
+import (
+	"regexp"
+	"strings"
+)
+
+var specialAttrCharsPattern = regexp.MustCompile(`[. ]`)
+
+// Create a Nix attribute name by quoting the string s if it contains
+// dots or spaces.
+func MakeAttrName(s string) string {
+	if strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"") ||
+		!specialAttrCharsPattern.MatchString(s) {
+		return s
+	}
+
+	return "\"" + s + "\""
+}
+
+// Create a Nix attribute path by joining attribute names with dots
+// and ignoring any empty attributes names.
+func MakeAttrPath[T ~string](values ...T) string {
+	var attrPath strings.Builder
+
+	for i := range values {
+		for _, value := range SplitAttrPath(string(values[i])) {
+			next := MakeAttrName(value)
+
+			if next != "" {
+				if attrPath.Len() > 0 {
+					attrPath.WriteString(".")
+				}
+				attrPath.WriteString(next)
+			}
+		}
+	}
+
+	return attrPath.String()
+}
+
+// Split an attribute path into its constituent components,
+// using '.' as a separator (if it is not enclosed in quotes),
+// and '\' as an escape character.
+func SplitAttrPath(s string) []string {
+	var parts []string
+	var str strings.Builder
+
+	escaped := false
+	quoted := false
+
+	for _, r := range s {
+		if escaped {
+			str.WriteRune(r)
+			escaped = false
+			continue
+		}
+
+		switch {
+		case r == '\\':
+			escaped = true
+
+		case r == '"':
+			quoted = !quoted
+
+		case r == '.' && !quoted:
+			parts = append(parts, str.String())
+			str.Reset()
+
+		default:
+			str.WriteRune(r)
+		}
+	}
+
+	parts = append(parts, str.String())
+	return parts
+}

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -1,0 +1,170 @@
+package nix_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/nix-community/nixos-cli/internal/nix"
+)
+
+func TestMakeAttrName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "a-z",
+			input: "foobar",
+			want:  "foobar",
+		},
+		{
+			name:  "space and dot",
+			input: "foo.bar ",
+			want:  "\"foo.bar \"",
+		},
+		{
+			name:  "space only",
+			input: " ",
+			want:  "\" \"",
+		},
+		{
+			name:  "dot only",
+			input: ".",
+			want:  "\".\"",
+		},
+		{
+			name:  "empty attribute",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "already quoted",
+			input: "\"foo.bar \"",
+			want:  "\"foo.bar \"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nix.MakeAttrName(tt.input)
+
+			if got != tt.want {
+				t.Errorf("Nix attribute name: got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeAttrPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  string
+	}{
+		{
+			name:  "no attributes",
+			input: []string{},
+			want:  "",
+		},
+		{
+			name:  "single attribute",
+			input: []string{"config"},
+			want:  "config",
+		},
+		{
+			name:  "multiple attributes",
+			input: []string{"config", "foo", "bar"},
+			want:  "config.foo.bar",
+		},
+		{
+			name:  "attribute path",
+			input: []string{"config", "config.foo.bar", "bar"},
+			want:  "config.config.foo.bar.bar",
+		},
+		{
+			name:  "space and dot",
+			input: []string{"config", "foo. ", "bar"},
+			want:  "config.foo.\" \".bar",
+		},
+		{
+			name:  "already quoted",
+			input: []string{"config", "\"foo. \"", "bar"},
+			want:  "config.\"foo. \".bar",
+		},
+		{
+			name:  "space only",
+			input: []string{"config", " ", "bar"},
+			want:  "config.\" \".bar",
+		},
+		{
+			name:  "dot only",
+			input: []string{"config", ".", "bar"},
+			want:  "config.bar",
+		},
+		{
+			name:  "escaped characters",
+			input: []string{"config", "f\\\\o\\\"o\\.", "bar"},
+			want:  "config.\"f\\o\"o.\".bar",
+		},
+		{
+			name:  "empty attributes",
+			input: []string{"", "config", "", "foo", "", "bar", ""},
+			want:  "config.foo.bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nix.MakeAttrPath(tt.input...)
+
+			if got != tt.want {
+				t.Errorf("Nix attribute path: got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitAttrPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty attribute",
+			input: "",
+			want:  []string{""},
+		},
+		{
+			name:  "single attribute",
+			input: "config",
+			want:  []string{"config"},
+		},
+		{
+			name:  "attribute path",
+			input: "config.fo o.bar",
+			want:  []string{"config", "fo o", "bar"},
+		},
+		{
+			name:  "escaped characters",
+			input: "config.f\\\\o\\\"o\\.bar",
+			want:  []string{"config", "f\\o\"o.bar"},
+		},
+		{
+			name:  "already quoted",
+			input: "config.\"fo\\\\o.bar\"",
+			want:  []string{"config", "fo\\o.bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nix.SplitAttrPath(tt.input)
+
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("Nix attribute path: got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces support for Nix attribute names containing spaces and dots. It involves creating two new types to represent attribute names and paths, and replacing `fmt.Sprintf()` calls with functions that use these types. It also adds `FlakeRef` and `LegacyConfiguration` functions to format common NixOS configuration attributes. 

I have tested local flake and legacy builds, images, specialisations, VMs, and evaluation of option values. I have not tested remote building (but it should also work).

Closes #126.