### PR TITLE
feat(apply): Allow deploying pre-built closures

### DIFF
--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -211,6 +211,27 @@ global *--config* flag as such:
 	This requires activation, and as such, conflicts with the *--no-activate*
 	option.
 
+*--store-path* <PATH>
+	Use a pre-built NixOS system store path at *PATH* instead of evaluating
+	and building from the configuration. This skips the evaluation and build
+	phases entirely. The path must be a valid NixOS system closure
+	(containing _nixos-version_ and _bin/switch-to-configuration_).
+
+	This is useful for deploying closures that were built elsewhere, such as
+	in CI systems or on remote build machines.
+
+	Cannot be used with [dry-]builds (i.e. passing both *--no-activate*
+	and *--no-boot*).
+
+	Mutually exclusive with the *FLAKE-REF* and *FILE* *ATTR*
+	arguments, as well as the *--vm[-with-bootloader]* and *--image*
+	options.
+
+	The following options are ignored when *--store-path* is specified:
+	*--output*, *--upgrade[-all]*, *--use-nom*.
+
+	If *--build-host* is specified then *PATH* must be valid on the build host.
+
 *-t*, *--tag* <DESCRIPTION>
 	Tag this generation with the given *DESCRIPTION*.
 

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -39,6 +39,7 @@ type ApplyOpts struct {
 	LocalRoot             bool
 	RemoteRoot            bool
 	Specialisation        string
+	StorePath             string
 	TargetHost            string
 	UpgradeAllChannels    bool
 	UpgradeChannels       bool

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -109,3 +109,24 @@ func ResolveNixFilename(input string) (string, error) {
 
 	return absolutePath, nil
 }
+
+func ResolveDirectory(input string) (string, error) {
+	fileInfo, err := os.Stat(input)
+	if err != nil {
+		return "", err
+	} else if !fileInfo.IsDir() {
+		return "", fmt.Errorf("not a directory: %v", input)
+	}
+
+	realPath, err := filepath.EvalSymlinks(input)
+	if err != nil {
+		return "", err
+	}
+
+	absolutePath, err := filepath.Abs(realPath)
+	if err != nil {
+		return "", err
+	}
+
+	return absolutePath, nil
+}


### PR DESCRIPTION
This adds a `--store-path` flag for deploying pre-built closures instead of building. This feature was recently added to `nixos-rebuild` (see NixOS/nixpkgs@d8fe9f45). 

Differences in this implementation:
 - Don't ignore `--build-host` since the store path is copied to the target host anyway.
 - Ignore `--upgrade[-all]` since there is no point in upgrading channels when not building.