### PR TITLE
fix(lint): add golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+version: '2'
+linters:
+  settings:
+    govet:
+      enable:
+        - printf
+      settings:
+        printf:
+          funcs:
+            - (github.com/nix-community/nixos-cli/internal/logger.Logger).Printf
+            - (github.com/nix-community/nixos-cli/internal/logger.Logger).Debugf
+            - (github.com/nix-community/nixos-cli/internal/logger.Logger).Infof
+            - (github.com/nix-community/nixos-cli/internal/logger.Logger).Warnf
+            - (github.com/nix-community/nixos-cli/internal/logger.Logger).Errorf
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/enter/run.go
+++ b/cmd/enter/run.go
@@ -132,7 +132,7 @@ resolvConfDone:
 		_ = unix.Close(sourceFd)
 	}
 	if resolvConfErr != nil {
-		log.Warnf("Internet access may not be available", err)
+		log.Warnf("Internet access may not be available")
 	}
 
 	systemClosure := opts.System

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -2,6 +2,7 @@ package info
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -48,9 +49,9 @@ func infoMain(cmd *cobra.Command, opts *cmdOpts.InfoOpts) error {
 	s := system.NewLocalSystem(log)
 
 	if !s.IsNixOS() {
-		msg := "the info command is only supported on NixOS systems"
-		log.Errorf(msg)
-		return fmt.Errorf("%v", msg)
+		err := errors.New("the info command is only supported on NixOS systems")
+		log.Errorf("%v", err)
+		return err
 	}
 
 	// Only support the `system` profile for now.

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -212,11 +212,10 @@ func validateMountpoint(log logger.Logger, mountpoint string) error {
 		hasCorrectPermission := mode.Perm()&0o005 >= 0o005
 
 		if !hasCorrectPermission {
-			msg := fmt.Sprintf("path %s should have permissions 755, but had permissions %s", currentPath, mode.Perm())
-			log.Errorf(msg)
-			log.Printf("hint: consider running `chmod o+rx %s", currentPath)
-
-			return fmt.Errorf("%v", msg)
+			err := fmt.Errorf("path %s should have permissions 755, but had permissions %o", currentPath, mode.Perm())
+			log.Errorf("%v", err)
+			log.Printf("hint: consider running `chmod o+rx %s`", currentPath)
+			return err
 		}
 	}
 

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -165,7 +165,7 @@ func optionMain(cmd *cobra.Command, opts *cmdOpts.OptionOpts) error {
 		if err != nil {
 			spinner.Stop()
 			log.Errorf("failed to build option list: %v", err)
-			log.Errorf("evaluation trace:", f)
+			log.Errorf("evaluation trace: %v", f)
 			return err
 		}
 		optionsFileName = f


### PR DESCRIPTION
Logger calls are not getting linted currently.

This PR adds a custom `.golangci.yml` file to configure this linting for the `Logger` interface by adding its functions to the `govet` `printf` tool's configuration, and corrects the subsequent detected bad usage of the `Logger` functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added strict code quality linting configuration to enforce higher standards.

* **Bug Fixes**
  * Improved error and warning message formatting across multiple commands for enhanced clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->