### PR TITLE
fix(apply): reduce restrictions on certain options

### DIFF
--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -216,6 +216,10 @@ func (f *FlakeRef) buildRemoteSystem(s *system.SSHSystem, buildType BuildType, o
 	realiseDrvArgv := []string{"nix-store", "-r", drvPath}
 	realiseDrvArgv = append(realiseDrvArgv, buildArgs...)
 
+	if opts.ResultLocation != "" {
+		realiseDrvArgv = append(realiseDrvArgv, "--add-root", opts.ResultLocation)
+	}
+
 	log.CmdArray(realiseDrvArgv)
 
 	var realisedPathBuf bytes.Buffer

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -236,6 +236,10 @@ func (l *LegacyConfiguration) buildRemoteSystem(s *system.SSHSystem, buildType B
 		realiseArgv = append(realiseArgv, "-k")
 	}
 
+	if opts.ResultLocation != "" {
+		realiseArgv = append(realiseArgv, "--add-root", opts.ResultLocation)
+	}
+
 	log.CmdArray(realiseArgv)
 
 	var realisedPathBuf bytes.Buffer


### PR DESCRIPTION
 - Allow passing `--no-activate` and `--no-boot` without having to specify `--output` or `--dry`.
It is useful to just test your configuration builds without creating a gc root and cluttering the filesystem.
 
 - When only building, print a log message to indicate the store path built.
This is mainly for when `--output` is not set, but I think it's useful to always show it when building only e.g., to be able to quickly copy the built store path for use in other commands. Also, `nixos-rebuild-ng` does this (and shows the store path even when switching).

 - Allow setting `--output` with `--build-host` and/or `--target-host`
To allow re-using aliases that set `--output ./result` with remote builds or activation.
 
- Don't change the working directory, it's not necessary for getting the latest commit message.
- Don't unnecessarily combine the output path with the working directory.
These last two changes are unrelated but I think they simplify the code at no cost. Happy to remove them if it should be a separate PR or if they are actually necessary.