### PR TITLE
fix(apply): fix resultLocation variable shadowing in build path

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -464,7 +464,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			NixOpts:  &opts.NixOptions,
 		}
 
-		resultLocation, err := nixConfig.BuildSystem(buildType, buildOptions)
+		var err error
+		resultLocation, err = nixConfig.BuildSystem(buildType, buildOptions)
 		if err != nil {
 			log.Errorf("failed to build configuration: %v", err)
 			return err


### PR DESCRIPTION
   The := operator was creating a new local resultLocation variable
   inside the if block, leaving the outer variable empty (""). This
   caused the diff command to receive an empty path:

     $ nvd diff /run/current-system
     error: a value is required for '\''[AFTER]'\'' but none was supplied

   Changed := to = with a pre-declared err variable so the build
   result path correctly assigns to the outer resultLocation.