### PR TITLE
feat(lint): prohibit var shadowing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     govet:
       enable:
         - printf
+        - shadow
       settings:
         printf:
           funcs:
@@ -12,6 +13,8 @@ linters:
             - (github.com/nix-community/nixos-cli/internal/logger.Logger).Infof
             - (github.com/nix-community/nixos-cli/internal/logger.Logger).Warnf
             - (github.com/nix-community/nixos-cli/internal/logger.Logger).Errorf
+        shadow:
+          strict: true
   exclusions:
     generated: lax
     presets:

--- a/cmd/activate/unit.go
+++ b/cmd/activate/unit.go
@@ -97,7 +97,8 @@ func (l *UnitLists) ClassifyActiveUnits(ctx context.Context, units map[string]Un
 		if treatAsNullUnit {
 			// Masked units (aka units that are symlinked to /dev/null) should be stopped
 			// if they contain the X-StopOnRemoval attribute.
-			unitInfo, err := systemdUtils.ParseUnit(resolvedUnit.CurrentUnitFile, resolvedUnit.CurrentBaseFile)
+			var unitInfo systemdUtils.UnitInfo
+			unitInfo, err = systemdUtils.ParseUnit(resolvedUnit.CurrentUnitFile, resolvedUnit.CurrentBaseFile)
 			if err != nil {
 				return err
 			}
@@ -106,7 +107,8 @@ func (l *UnitLists) ClassifyActiveUnits(ctx context.Context, units map[string]Un
 				l.Stop.Add(unit)
 			}
 		} else if strings.HasSuffix(unit, ".target") {
-			newUnitInfo, err := systemdUtils.ParseUnit(resolvedUnit.NewUnitFile, resolvedUnit.NewBaseFile)
+			var newUnitInfo systemdUtils.UnitInfo
+			newUnitInfo, err = systemdUtils.ParseUnit(resolvedUnit.NewUnitFile, resolvedUnit.NewBaseFile)
 			if err != nil {
 				return err
 			}
@@ -142,19 +144,21 @@ func (l *UnitLists) ClassifyActiveUnits(ctx context.Context, units map[string]Un
 				l.Stop.Add(unit)
 			}
 		} else {
-			currentUnitInfo, err := systemdUtils.ParseUnit(resolvedUnit.CurrentUnitFile, resolvedUnit.CurrentBaseFile)
+			var currentUnitInfo systemdUtils.UnitInfo
+			currentUnitInfo, err = systemdUtils.ParseUnit(resolvedUnit.CurrentUnitFile, resolvedUnit.CurrentBaseFile)
 			if err != nil {
 				return err
 			}
 
-			newUnitInfo, err := systemdUtils.ParseUnit(resolvedUnit.NewUnitFile, resolvedUnit.NewBaseFile)
+			var newUnitInfo systemdUtils.UnitInfo
+			newUnitInfo, err = systemdUtils.ParseUnit(resolvedUnit.NewUnitFile, resolvedUnit.NewBaseFile)
 			if err != nil {
 				return err
 			}
 
 			switch systemdUtils.CompareUnits(currentUnitInfo, newUnitInfo) {
 			case systemdUtils.UnitComparisonNeedsRestart:
-				err := l.ClassifyModifiedUnit(
+				err = l.ClassifyModifiedUnit(
 					unit,
 					resolvedUnit.BaseName,
 					resolvedUnit.NewUnitFile,
@@ -493,7 +497,7 @@ func resolveUnit(unit, toplevel string) ResolvedUnit {
 		templateName, _, unitType := matches[1], matches[2], matches[3]
 
 		if _, err := os.Stat(currentUnitFile); os.IsNotExist(err) {
-			if _, err := os.Stat(newUnitFile); os.IsNotExist(err) {
+			if _, err = os.Stat(newUnitFile); os.IsNotExist(err) {
 				baseUnit = fmt.Sprintf("%s@.%s", templateName, unitType)
 				currentBaseFile = filepath.Join("/etc/systemd/system", baseUnit)
 				newBaseFile = filepath.Join(toplevel, "etc/systemd/system", baseUnit)

--- a/cmd/activate/user.go
+++ b/cmd/activate/user.go
@@ -46,7 +46,7 @@ func userSwitch(log logger.Logger, parentExe string) error {
 	}
 
 	if childExe != parentExe {
-		err := fmt.Errorf("this program is not meant to be called from outside of `nixos activate`")
+		err = fmt.Errorf("this program is not meant to be called from outside of `nixos activate`")
 		log.Error(err)
 		return err
 	}
@@ -77,7 +77,7 @@ func userSwitch(log logger.Logger, parentExe string) error {
 
 	status := <-nixosActivationStatus
 	if status == "timeout" || status == "failed" || status == "dependency" {
-		err := fmt.Errorf("restarting nixos-activation.service failed with status %s", status)
+		err = fmt.Errorf("restarting nixos-activation.service failed with status %s", status)
 		log.Error(err)
 		return err
 	}

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -386,7 +386,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			}
 
 			if slices.Index(images, imgBuild.Variant) < 0 {
-				err := fmt.Errorf("image type '%s' is not available", imgBuild.Variant)
+				err = fmt.Errorf("image type '%s' is not available", imgBuild.Variant)
 				log.Error(err)
 				log.Info("pass an empty string to `--image` to get a list of available images")
 				return err
@@ -433,7 +433,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			if err != nil {
 				log.Warnf("failed to resolve configuration path: %v", err)
 			} else {
-				commitMsg, err := getLatestGitCommitMessage(configDirname, cfg.Apply.IgnoreDirtyTree)
+				var commitMsg string
+				commitMsg, err = getLatestGitCommitMessage(configDirname, cfg.Apply.IgnoreDirtyTree)
 				if err == errDirtyGitTree {
 					log.Warn("git tree is dirty")
 				} else if err != nil {
@@ -532,7 +533,9 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		log.Printf("\n")
-		confirm, err := cmdUtils.ConfirmationInput("Activate this configuration?", cmdUtils.ConfirmationPromptOptions{
+
+		var confirm bool
+		confirm, err = cmdUtils.ConfirmationInput("Activate this configuration?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})
@@ -557,7 +560,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	specialisation := opts.Specialisation
 	if specialisation == "" {
-		defaultSpecialisation, err := activation.FindDefaultSpecialisationFromConfig(targetHost, resultLocation)
+		var defaultSpecialisation string
+		defaultSpecialisation, err = activation.FindDefaultSpecialisationFromConfig(targetHost, resultLocation)
 		if err != nil {
 			log.Warnf("unable to find default specialisation from config: %v", err)
 		} else {
@@ -593,7 +597,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			return err
 		}
 
-		if err := activation.AddNewNixProfile(
+		if err = activation.AddNewNixProfile(
 			targetHost,
 			opts.ProfileName,
 			resultLocation,
@@ -627,7 +631,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 			log.Step("Rolling back system profile...")
 
-			if err := activation.SetNixProfileGeneration(
+			if err = activation.SetNixProfileGeneration(
 				targetHost,
 				opts.ProfileName,
 				previousGenNumber, &activation.SetNixProfileGenerationOptions{
@@ -700,7 +704,7 @@ func upgradeChannels(s system.CommandRunner, opts *upgradeChannelsOptions) error
 
 		for _, entry := range entries {
 			if entry.IsDir() {
-				if _, err := os.Stat(filepath.Join(channelDirectory, entry.Name(), ".update-on-nixos-rebuild")); err == nil {
+				if _, err = os.Stat(filepath.Join(channelDirectory, entry.Name(), ".update-on-nixos-rebuild")); err == nil {
 					argv = append(argv, entry.Name())
 				}
 			}

--- a/cmd/features/features.go
+++ b/cmd/features/features.go
@@ -34,15 +34,15 @@ func FeatureCommand() *cobra.Command {
 	return &cmd
 }
 
-type features struct {
-	Version            string              `json:"version"`
-	GitRevision        string              `json:"git_rev"`
-	GoVersion          string              `json:"go_version"`
-	DetectedNixVersion string              `json:"nix_version"`
-	CompilationOptions complilationOptions `json:"options"`
+type AvailableFeatures struct {
+	Version            string             `json:"version"`
+	GitRevision        string             `json:"git_rev"`
+	GoVersion          string             `json:"go_version"`
+	DetectedNixVersion string             `json:"nix_version"`
+	CompilationOptions CompilationOptions `json:"options"`
 }
 
-type complilationOptions struct {
+type CompilationOptions struct {
 	NixpkgsVersion string `json:"nixpkgs_version"`
 	Flake          bool   `json:"flake"`
 }
@@ -50,11 +50,11 @@ type complilationOptions struct {
 func featuresMain(cmd *cobra.Command, opts *cmdOpts.FeaturesOpts) {
 	log := logger.FromContext(cmd.Context())
 
-	features := features{
+	features := AvailableFeatures{
 		Version:     build.Version(),
 		GitRevision: build.GitRevision(),
 		GoVersion:   runtime.Version(),
-		CompilationOptions: complilationOptions{
+		CompilationOptions: CompilationOptions{
 			NixpkgsVersion: build.NixpkgsVersion(),
 			Flake:          build.Flake(),
 		},

--- a/cmd/generation/delete/delete.go
+++ b/cmd/generation/delete/delete.go
@@ -166,7 +166,8 @@ func generationDeleteMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 	log.Print()
 
 	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
-		confirm, err := cmdUtils.ConfirmationInput("Proceed?", cmdUtils.ConfirmationPromptOptions{
+		var confirm bool
+		confirm, err = cmdUtils.ConfirmationInput("Proceed?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})
@@ -183,21 +184,21 @@ func generationDeleteMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 	log.Step("Deleting generations...")
 
 	profileDirectory := generation.GetProfileDirectoryFromName(genOpts.ProfileName)
-	if err := deleteGenerations(s, profileDirectory, gensToDelete); err != nil {
+	if err = deleteGenerations(s, profileDirectory, gensToDelete); err != nil {
 		log.Errorf("failed to delete generations: %v", err)
 		return err
 	}
 
 	log.Step("Regenerating boot menu entries...")
 
-	if err := regenerateBootMenu(s); err != nil {
+	if err = regenerateBootMenu(s); err != nil {
 		log.Errorf("failed to regenerate boot menu entries: %v", err)
 		return err
 	}
 
 	log.Step("Collecting garbage...")
 
-	if err := collectGarbage(s); err != nil {
+	if err = collectGarbage(s); err != nil {
 		log.Errorf("failed to collect garbage: %v", err)
 		return err
 	}

--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -93,7 +93,9 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 
 	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		log.Printf("\n")
-		confirm, err := cmdUtils.ConfirmationInput("Activate the previous generation?", cmdUtils.ConfirmationPromptOptions{
+
+		var confirm bool
+		confirm, err = cmdUtils.ConfirmationInput("Activate the previous generation?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})
@@ -110,7 +112,8 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 
 	specialisation := opts.Specialisation
 	if specialisation == "" {
-		defaultSpecialisation, err := activation.FindDefaultSpecialisationFromConfig(s, generationLink)
+		var defaultSpecialisation string
+		defaultSpecialisation, err = activation.FindDefaultSpecialisationFromConfig(s, generationLink)
 		if err != nil {
 			log.Warnf("unable to find default specialisation from config: %v", err)
 		} else {
@@ -133,7 +136,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 	if !opts.Dry {
 		log.Step("Setting system profile...")
 
-		if err := activation.SetNixProfileGeneration(
+		if err = activation.SetNixProfileGeneration(
 			s,
 			genOpts.ProfileName,
 			uint64(previousGen.Number),
@@ -163,7 +166,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 			}
 
 			log.Step("Rolling back system profile...")
-			if err := activation.SetNixProfileGeneration(
+			if err = activation.SetNixProfileGeneration(
 				s,
 				genOpts.ProfileName,
 				previousGenNumber,

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -145,7 +145,9 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 
 	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		log.Printf("\n")
-		confirm, err := cmdUtils.ConfirmationInput("Activate this generation?", cmdUtils.ConfirmationPromptOptions{
+
+		var confirm bool
+		confirm, err = cmdUtils.ConfirmationInput("Activate this generation?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})
@@ -162,7 +164,8 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 
 	specialisation := opts.Specialisation
 	if specialisation == "" {
-		defaultSpecialisation, err := activation.FindDefaultSpecialisationFromConfig(s, generationLink)
+		var defaultSpecialisation string
+		defaultSpecialisation, err = activation.FindDefaultSpecialisationFromConfig(s, generationLink)
 		if err != nil {
 			log.Warnf("unable to find default specialisation from config: %v", err)
 		} else {
@@ -185,7 +188,7 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 	if !opts.Dry {
 		log.Step("Setting system profile...")
 
-		if err := activation.SetNixProfileGeneration(
+		if err = activation.SetNixProfileGeneration(
 			s,
 			genOpts.ProfileName,
 			uint64(opts.Generation),
@@ -215,7 +218,7 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 			}
 
 			log.Step("Rolling back system profile...")
-			if err := activation.SetNixProfileGeneration(
+			if err = activation.SetNixProfileGeneration(
 				s,
 				genOpts.ProfileName,
 				previousGenNumber,

--- a/cmd/init/filesystems.go
+++ b/cmd/init/filesystems.go
@@ -94,7 +94,8 @@ func findFilesystems(log logger.Logger, rootDir string) []Filesystem {
 
 		absoluteMountpoint := strings.ReplaceAll(fields[4], "\\040", "")
 
-		if stat, err := os.Stat(absoluteMountpoint); err != nil || !stat.IsDir() {
+		var info os.FileInfo
+		if info, err = os.Stat(absoluteMountpoint); err != nil || !info.IsDir() {
 			continue
 		}
 
@@ -182,7 +183,8 @@ func findFilesystems(log logger.Logger, rootDir string) []Filesystem {
 
 			backerFilename := fmt.Sprintf("/sys/block/loop%s/loop/backing_file", loopNumber)
 
-			if backer, err := os.ReadFile(backerFilename); err == nil {
+			var backer []byte
+			if backer, err = os.ReadFile(backerFilename); err == nil {
 				devicePath = string(backer)
 				extraOptions = append(extraOptions, "loop")
 			}
@@ -306,7 +308,8 @@ func checkDirForEqualDevice(deviceRdev uint64, dirname string) (string, bool) {
 
 	for _, entry := range entries {
 		devicePath := filepath.Join(dirname, entry.Name())
-		rdev, err := getRdev(devicePath)
+		var rdev uint64
+		rdev, err = getRdev(devicePath)
 		if err != nil {
 			continue
 		}

--- a/cmd/init/generate.go
+++ b/cmd/init/generate.go
@@ -184,7 +184,7 @@ func generateConfigNix(log logger.Logger, cfg *settings.Settings, virtType Virtu
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 `
-	} else if _, err := os.Stat("/boot/extlinux"); err == nil {
+	} else if _, err = os.Stat("/boot/extlinux"); err == nil {
 		log.Info("extlinux bootloader detected, using generic-extlinux-compatible bootloader")
 
 		bootloaderConfig = `  # Use the extlinux bootloader.

--- a/cmd/init/run.go
+++ b/cmd/init/run.go
@@ -56,7 +56,7 @@ func initMain(cmd *cobra.Command, opts *cmdOpts.InitOpts) error {
 		flakeNixFilename := filepath.Join(configDir, "flake.nix")
 		log.Infof("writing %v", flakeNixFilename)
 
-		if _, err := os.Stat(flakeNixFilename); err == nil {
+		if _, err = os.Stat(flakeNixFilename); err == nil {
 			if opts.ForceWrite {
 				log.Warn("overwriting existing flake.nix")
 			} else {
@@ -74,7 +74,7 @@ func initMain(cmd *cobra.Command, opts *cmdOpts.InitOpts) error {
 
 	configNixFilename := filepath.Join(configDir, "configuration.nix")
 	log.Infof("writing %v", configNixFilename)
-	if _, err := os.Stat(configNixFilename); err == nil {
+	if _, err = os.Stat(configNixFilename); err == nil {
 		if opts.ForceWrite {
 			log.Warn("overwriting existing configuration.nix")
 		} else {
@@ -90,7 +90,7 @@ func initMain(cmd *cobra.Command, opts *cmdOpts.InitOpts) error {
 
 	hwConfigNixFilename := filepath.Join(configDir, "hardware-configuration.nix")
 	log.Infof("writing %v", hwConfigNixFilename)
-	if _, err := os.Stat(hwConfigNixFilename); err == nil {
+	if _, err = os.Stat(hwConfigNixFilename); err == nil {
 		log.Warn("overwriting existing hardware-configuration.nix")
 	}
 	err = os.WriteFile(hwConfigNixFilename, []byte(hwConfigNixText), 0o644)

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -203,7 +203,8 @@ func validateMountpoint(log logger.Logger, mountpoint string) error {
 
 		currentPath = filepath.Join(currentPath, component)
 
-		info, err := os.Stat(currentPath)
+		var info os.FileInfo
+		info, err = os.Stat(currentPath)
 		if err != nil {
 			return fmt.Errorf("failed to stat %s: %w", currentPath, err)
 		}
@@ -212,7 +213,7 @@ func validateMountpoint(log logger.Logger, mountpoint string) error {
 		hasCorrectPermission := mode.Perm()&0o005 >= 0o005
 
 		if !hasCorrectPermission {
-			err := fmt.Errorf("path %s should have permissions 755, but had permissions %o", currentPath, mode.Perm())
+			err = fmt.Errorf("path %s should have permissions 755, but had permissions %o", currentPath, mode.Perm())
 			log.Errorf("%v", err)
 			log.Printf("hint: consider running `chmod o+rx %s`", currentPath)
 			return err
@@ -246,7 +247,7 @@ func copyChannel(cobraCmd *cobra.Command, s system.CommandRunner, mountpoint str
 		cmd := system.NewCommand(argv[0], argv[1:]...)
 		cmd.Stdout = &stdout
 
-		_, err := s.Run(cmd)
+		_, err = s.Run(cmd)
 		if err != nil {
 			log.Errorf("failed to obtain default nixos channel location: %v", err)
 			return err
@@ -402,7 +403,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 		return err
 	}
 
-	if err := validateMountpoint(log, mountpoint); err != nil {
+	if err = validateMountpoint(log, mountpoint); err != nil {
 		return err
 	}
 	tmpDirname, err := os.MkdirTemp(mountpoint, "system")
@@ -430,7 +431,8 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 			nixConfig = opts.FlakeRef
 			log.Debugf("using flake ref %s", opts.FlakeRef)
 		} else if opts.File != "" {
-			configPath, err := utils.ResolveNixFilename(opts.File)
+			var configPath string
+			configPath, err = utils.ResolveNixFilename(opts.File)
 			if err != nil {
 				log.Error(err)
 				return err
@@ -457,7 +459,8 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 				configLocation = filepath.Join(mountpoint, "etc", "nixos", "configuration.nix")
 			}
 
-			resolvedLocation, err := utils.ResolveNixFilename(configLocation)
+			var resolvedLocation string
+			resolvedLocation, err = utils.ResolveNixFilename(configLocation)
 			if err != nil {
 				log.Errorf("failed to find configuration: %v", err)
 				return err
@@ -494,7 +497,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 			// This value gets appended to the list of includes,
 			// and does not replace existing values already provided
 			// for -I on the command line.
-			if err := cmd.Flags().Set("include", fmt.Sprintf("nixos-config=%s", c.ConfigPath)); err != nil {
+			if err = cmd.Flags().Set("include", fmt.Sprintf("nixos-config=%s", c.ConfigPath)); err != nil {
 				panic("failed to set --include flag for nixos install command for legacy systems")
 			}
 		}
@@ -519,7 +522,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 
 	log.Step("Creating initial generation...")
 
-	if err := createInitialGeneration(s, mountpoint, resultLocation); err != nil {
+	if err = createInitialGeneration(s, mountpoint, resultLocation); err != nil {
 		return err
 	}
 
@@ -545,7 +548,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 	if !opts.NoBootloader {
 		log.Step("Installing bootloader...")
 
-		if err := installBootloader(s, mountpoint); err != nil {
+		if err = installBootloader(s, mountpoint); err != nil {
 			return err
 		}
 	}
@@ -559,7 +562,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 			log.Warn("stdin is not a terminal; skipping setting root password")
 			log.Info(manualHint)
 		} else {
-			err := setRootPassword(s, mountpoint)
+			err = setRootPassword(s, mountpoint)
 			if err != nil {
 				log.Warnf("failed to set root password: %v", err)
 				log.Info(manualHint)

--- a/cmd/option/completion.go
+++ b/cmd/option/completion.go
@@ -34,12 +34,14 @@ func loadOptions(log logger.Logger, cfg *settings.Settings, includes []string) (
 	optionsFileName := prebuiltOptionCachePath
 	if !useCache {
 		log.Info("building options list")
-		f, err := buildOptionCache(s, nixosConfig)
+
+		var filename string
+		filename, err = buildOptionCache(s, nixosConfig)
 		if err != nil {
 			log.Errorf("failed to build option list: %v", err)
 			return nil, err
 		}
-		optionsFileName = f
+		optionsFileName = filename
 	}
 
 	optionsFile, err := os.Open(optionsFileName)

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -185,7 +185,8 @@ func optionMain(cmd *cobra.Command, opts *cmdOpts.OptionOpts) error {
 	}
 
 	var evaluator option.EvaluatorFunc = func(optionName string) (string, error) {
-		value, err := nixosConfig.EvalAttribute(optionName)
+		var value *string
+		value, err = nixosConfig.EvalAttribute(optionName)
 		realValue := ""
 		if value != nil {
 			realValue = *value
@@ -230,7 +231,8 @@ func optionMain(cmd *cobra.Command, opts *cmdOpts.OptionOpts) error {
 
 		spinner.UpdateMessage("Evaluating option value...")
 
-		evaluatedValue, err := evaluator(o.Name)
+		var evaluatedValue string
+		evaluatedValue, err = evaluator(o.Name)
 
 		spinner.Stop()
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -73,8 +73,7 @@ func mainCommand() (*cobra.Command, error) {
 		cfg = settings.NewSettings()
 	}
 
-	errs := cfg.Validate()
-	for _, err := range errs {
+	for _, err := range cfg.Validate() {
 		log.Warn(err.Error())
 	}
 
@@ -92,7 +91,7 @@ func mainCommand() (*cobra.Command, error) {
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			for key, value := range opts.ConfigValues {
-				err := cfg.SetValue(key, value)
+				err = cfg.SetValue(key, value)
 				if err != nil {
 					return fmt.Errorf("failed to set %v: %w", key, err)
 				}
@@ -152,7 +151,7 @@ func mainCommand() (*cobra.Command, error) {
 	cmd.AddCommand(replCmd.ReplCommand())
 
 	for alias, resolved := range cfg.Aliases {
-		err := addAliasCmd(&cmd, alias, resolved)
+		err = addAliasCmd(&cmd, alias, resolved)
 		if err != nil {
 			log.Warnf("failed to add alias '%v': %v", alias, err.Error())
 		}

--- a/doc/build.go
+++ b/doc/build.go
@@ -354,7 +354,7 @@ func generateManPages(inputDir string, outputDir string) error {
 		cmd.Stdout = &outBuf
 		cmd.Stderr = os.Stderr
 
-		if err := cmd.Run(); err != nil {
+		if err = cmd.Run(); err != nil {
 			return fmt.Errorf("scdoc failed for %s: %w", path, err)
 		}
 
@@ -362,7 +362,7 @@ func generateManPages(inputDir string, outputDir string) error {
 		manFile := base[:len(base)-len(".scd")]
 		outPath := filepath.Join(outputDir, manFile)
 
-		if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		if err = os.MkdirAll(outputDir, 0o755); err != nil {
 			return err
 		}
 

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -168,12 +168,13 @@ func GetCurrentGenerationNumber(s system.System, profile string) (uint64, error)
 	}
 
 	if matches := genLinkRegex.FindStringSubmatch(currentGenerationLink); len(matches) > 0 {
-		genNumber, err := strconv.ParseInt(matches[1], 10, 64)
+		var genNumber uint64
+		genNumber, err = strconv.ParseUint(matches[1], 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse generation number %v for %v", matches[1], currentGenerationLink)
 		}
 
-		return uint64(genNumber), nil
+		return genNumber, nil
 	} else {
 		panic("current link format does not match 'profile-generation-link' format")
 	}

--- a/internal/cmd/nixopts/convert.go
+++ b/internal/cmd/nixopts/convert.go
@@ -92,7 +92,7 @@ func NixOptionsToArgsListByCategory(flags *pflag.FlagSet, options any, category 
 	val := reflect.ValueOf(options)
 	typ := reflect.TypeOf(options)
 
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 		typ = typ.Elem()
 	}
@@ -106,7 +106,7 @@ func NixOptionsToArgsListByCategory(flags *pflag.FlagSet, options any, category 
 		nixOption := getNixFlag(fieldType.Name)
 
 		categories := strings.Split(fieldType.Tag.Get("nixCategory"), ",")
-		if i := slices.Index(categories, category); i == -1 {
+		if categoryIndex := slices.Index(categories, category); categoryIndex == -1 {
 			continue
 		}
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -49,7 +49,7 @@ func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []str
 			return nil, err
 		}
 
-		if err := f.InferSystemFromHostnameIfNeeded(); err != nil {
+		if err = f.InferSystemFromHostnameIfNeeded(); err != nil {
 			return nil, err
 		}
 

--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -33,7 +33,8 @@ func FlakeRefFromString(s string) *FlakeRef {
 	}
 
 	if _, err := os.Stat(uri); err == nil {
-		if resolved, err := filepath.EvalSymlinks(uri); err == nil {
+		var resolved string
+		if resolved, err = filepath.EvalSymlinks(uri); err == nil {
 			uri = resolved
 		}
 	}

--- a/internal/generation/completion.go
+++ b/internal/generation/completion.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var genLinkRegex = regexp.MustCompile(`-(\d+)-link$`)
+var genLinkPattern = regexp.MustCompile(`-(\d+)-link$`)
 
 func CompleteProfileFlag(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	profiles := []string{"system"}
@@ -26,7 +26,7 @@ func CompleteProfileFlag(_ *cobra.Command, args []string, toComplete string) ([]
 	for _, v := range entries {
 		name := v.Name()
 
-		if matches := genLinkRegex.FindStringSubmatch(name); len(matches) > 0 {
+		if matches := genLinkPattern.FindStringSubmatch(name); len(matches) > 0 {
 			continue
 		}
 
@@ -53,7 +53,8 @@ func CompleteGenerationNumber(profile *string, limit int) cobra.CompletionFunc {
 
 		exclude := []uint64{}
 		for _, v := range args {
-			parsed, err := strconv.ParseUint(v, 10, 64)
+			var parsed uint64
+			parsed, err = strconv.ParseUint(v, 10, 64)
 			if err != nil {
 				continue
 			}

--- a/internal/ssh/host.go
+++ b/internal/ssh/host.go
@@ -78,12 +78,14 @@ func ParseUserHostPort(s string) (*UserHostPort, error) {
 
 	var port int
 	if portStr != "" {
-		p, err := parsePort(portStr)
+		var parsedPort int
+
+		parsedPort, err = parsePort(portStr)
 		if err != nil {
 			return nil, err
 		}
 
-		port = p
+		port = parsedPort
 	}
 
 	ret := &UserHostPort{

--- a/internal/system/local.go
+++ b/internal/system/local.go
@@ -63,7 +63,10 @@ func (l *LocalSystem) Run(cmd *Command) (int, error) {
 	err := command.Wait()
 
 	if exitErr, ok := err.(*exec.ExitError); ok {
-		if status, ok := exitErr.Sys().(interface{ ExitStatus() int }); ok {
+		type exitStatusImpl interface{ ExitStatus() int }
+
+		var status exitStatusImpl
+		if status, ok = exitErr.Sys().(exitStatusImpl); ok {
 			return status.ExitStatus(), err
 		}
 	}

--- a/internal/systemd/unit.go
+++ b/internal/systemd/unit.go
@@ -47,7 +47,7 @@ func ParseUnit(unitFilePath string, baseUnitFilePath string) (UnitInfo, error) {
 
 	if unitFilePath != baseUnitFilePath {
 		if _, err := os.Stat(unitFilePath); err == nil {
-			matches, _ := filepath.Glob(fmt.Sprintf("%s.d/*.conf", unitFilePath))
+			matches, _ = filepath.Glob(fmt.Sprintf("%s.d/*.conf", unitFilePath))
 			for _, path := range matches {
 				_ = parseAndMerge(path)
 			}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -82,7 +82,8 @@ func ResolveNixFilename(input string) (string, error) {
 	} else {
 		defaultNix := filepath.Join(input, "default.nix")
 
-		defaultNixInfo, err := os.Stat(defaultNix)
+		var defaultNixInfo os.FileInfo
+		defaultNixInfo, err = os.Stat(defaultNix)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Lax variable shadowing rules have caused bugs in the past, especially in #169 and elsewhere.

This takes a more restrictive approach: variable shadowing is now completely disallowed in most situations. It does make short-hand variable assignments a little harder to write in cases with common variable names like `err`, but this is a worthwhile tradeoff IMO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized code structure throughout multiple modules to improve consistency and maintainability.
  * Enhanced internal type definitions and improved variable declaration patterns for better code clarity.

* **Chores**
  * Integrated additional code linting tools to maintain higher code quality standards across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->