### PR TITLE
feat(ssh): add configuration

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -236,7 +236,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	if opts.TargetHost != "" {
 		log.Debugf("connecting to %s", opts.TargetHost)
-		host, err := system.NewSSHSystem(opts.TargetHost, log)
+		host, err := system.NewSSHSystem(localSystem, opts.TargetHost, log, cfg)
 		if err != nil {
 			log.Errorf("%v", err)
 			return err
@@ -298,7 +298,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 	if opts.BuildHost != "" {
 		log.Debugf("connecting to %s", opts.BuildHost)
-		host, err := system.NewSSHSystem(opts.BuildHost, log)
+		host, err := system.NewSSHSystem(localSystem, opts.BuildHost, log, cfg)
 		if err != nil {
 			log.Errorf("%v", err)
 			return err

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -127,8 +127,15 @@ global *--config* flag as such:
 
 	*HOST* is a simple SSH address with the format "_user@address:port_".
 
-	SSH keys must be loaded into _ssh-agent_ for them to be used by the program.
-	If an agent is not detected, then an error will be displayed.
+	SSH can be authenticated using private keys via the following methods:
+	- the *ssh.private_key_cmd* setting (see *nixos-cli-settings(5)*)
+	- an SSH agent (detected via *$SSH_AUTH_SOCK*)
+
+	Each method will be attempted once, in order. If none of them are configured,
+	or all fail, password authentication will be attempted.
+
+	You can pass extra ssh options to _nix-copy-closure_ by defining the
+	environment variable _$NIX_SSHOPTS_.
 
 	If *--target-host* is not set, the build will be copied back to the local
 	machine when done.

--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -87,6 +87,9 @@ Among other things.
 	_nixos activate_ skips syncing the Nix store to disk before activating. Can
 	speed up activations at the cost of risking data loss if interrupted.
 
+*NIX_SSHOPTS*
+	Additional ssh options to be passed to _nix-copy-closure_ on the command line.
+
 *STC_DISPLAY_ALL_UNITS*
 	Show all actual units that are being modified by _nixos activate_.
 

--- a/doc/src/overview.md
+++ b/doc/src/overview.md
@@ -93,9 +93,10 @@ automatically escalates to `root` using the command defined in the
 `root_command` setting. If you wish not to enter a password, then deploy using a
 user that has the `NOPASSWD` `sudo` rule.
 
-In order to access remote machines, prefer using an SSH agent and keys. Password
-access is supported, but not recommended, and can be buggy. If you find any
-issues, report them on the issue tracker.
+In order to access remote machines, it is recommended to use SSH keys managed by
+an SSH agent, or to provide a key via the `ssh.private_key_cmd` setting. Password
+access is supported, but not recommended, and can be buggy. If you find any issues,
+report them on the issue tracker.
 
 ### `nixos-enter`
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -24,6 +24,7 @@ type Settings struct {
 	Init           InitSettings         `koanf:"init"`
 	NoConfirm      bool                 `koanf:"no_confirm"`
 	Option         OptionSettings       `koanf:"option"`
+	SSH            SSHSettings          `koanf:"ssh"`
 	RootCommand    string               `koanf:"root_command"`
 	UseNvd         bool                 `koanf:"use_nvd"`
 }
@@ -58,6 +59,11 @@ type OptionSettings struct {
 	MinScore     int64 `koanf:"min_score"`
 	Prettify     bool  `koanf:"prettify"`
 	DebounceTime int64 `koanf:"debounce_time"`
+}
+
+type SSHSettings struct {
+	KnownHostsFiles []string `koanf:"known_hosts_files"`
+	PrivateKeyCmd   []string `koanf:"private_key_cmd"`
 }
 
 type ConfirmationPromptBehavior string
@@ -99,6 +105,10 @@ rollback = ["generation", "rollback"]
 
 	confirmationInputPossibleValues = "Possible values are `default-no` (treat as a no input), `default-yes` (treat as a yes input), or `retry` (try again)."
 	deprecatedDocString             = "This setting has been deprecated, and will be removed in a future release."
+
+	sshPrivateKeyCmdExample = "```\n" + `[ssh]
+private_key_cmd = ["sh", "-c", "rbw get $NIXOS_CLI_SSH_HOST"]
+` + "```\n"
 )
 
 var SettingsDocs = map[string]DescriptionEntry{
@@ -200,6 +210,20 @@ var SettingsDocs = map[string]DescriptionEntry{
 		Short: "Debounce time for searching options using the UI, in milliseconds",
 		Long:  "Controls how often search results are recomputed when typing in the options UI, in milliseconds.",
 	},
+	"ssh": {
+		Short: "Settings for ssh",
+	},
+	"ssh.known_hosts_files": {
+		Short: "List of paths to known hosts files",
+		Long:  "List of paths to known hosts files. `/etc/ssh/ssh_known_hosts` and `$HOME/.ssh/known_hosts` are always included.",
+	},
+	"ssh.private_key_cmd": {
+		Short: "Command to run to obtain SSH private key",
+		Long: "Specifies the command to run to obtain the private key for SSH connections." +
+			" The command receives the host and user as the environment variables $NIXOS_CLI_SSH_HOST" +
+			" and $NIXOS_CLI_SSH_USER respectively, and should output a single private key to standard output." +
+			"\nExample:\n" + sshPrivateKeyCmdExample,
+	},
 	"root_command": {
 		Short: "Command to use to promote process to root",
 		Long:  "Specifies which command to use for privilege escalation (e.g., sudo or doas).",
@@ -230,6 +254,7 @@ func NewSettings() *Settings {
 			Prettify:     true,
 			DebounceTime: 25,
 		},
+		SSH: SSHSettings{},
 	}
 }
 

--- a/internal/system/tempfile_linux.go
+++ b/internal/system/tempfile_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package system
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+type TempFile struct {
+	memFd int
+}
+
+func NewTempFile(pattern string, content []byte) (*TempFile, error) {
+	memFd, err := unix.MemfdCreate(pattern, unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING|unix.MFD_NOEXEC_SEAL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create memfd: %v", err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = unix.Close(memFd)
+		}
+	}()
+
+	if _, err = unix.Write(memFd, content); err != nil {
+		return nil, fmt.Errorf("failed to write to memfd: %v", err)
+	}
+
+	_, err = unix.FcntlInt(uintptr(memFd), unix.F_ADD_SEALS, unix.F_SEAL_SEAL|unix.F_SEAL_SHRINK|unix.F_SEAL_GROW|unix.F_SEAL_WRITE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add seals to memfd: %v", err)
+	}
+
+	if err = unix.Fchmod(memFd, 0o400); err != nil {
+		return nil, fmt.Errorf("failed to change permissions of memfd: %v", err)
+	}
+
+	t := TempFile{
+		memFd: memFd,
+	}
+
+	return &t, nil
+}
+
+func (t *TempFile) Path() string {
+	return fmt.Sprintf("/proc/%v/fd/%v", os.Getpid(), t.memFd)
+}
+
+func (t *TempFile) Remove() error {
+	return unix.Close(t.memFd)
+}

--- a/internal/system/tempfile_other.go
+++ b/internal/system/tempfile_other.go
@@ -1,0 +1,54 @@
+//go:build !linux
+
+package system
+
+import (
+	"fmt"
+	"os"
+)
+
+type TempFile struct {
+	path string
+}
+
+func NewTempFile(pattern string, content []byte) (*TempFile, error) {
+	file, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tempfile: %v", err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = file.Close()
+			_ = os.Remove(file.Name())
+		}
+	}()
+
+	if _, err = file.Write(content); err != nil {
+		return nil, fmt.Errorf("failed to write to tempfile: %v", err)
+	}
+
+	if err = file.Chmod(0o400); err != nil {
+		return nil, fmt.Errorf("failed to change permissions of tempfile: %v", err)
+	}
+
+	path := file.Name()
+
+	if err = file.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close tempfile: %v", err)
+	}
+
+	t := TempFile{
+		path: path,
+	}
+
+	return &t, nil
+}
+
+func (t *TempFile) Path() string {
+	return t.path
+}
+
+func (t *TempFile) Remove() error {
+	return os.Remove(t.path)
+}


### PR DESCRIPTION
 - Add a setting to specify the path to the known hosts file
I need this since I use `programs.ssh.knownHosts` to set up known hosts, which stores them in `/etc/ssh/ssh_known_hosts`, and extra known hosts files can be set with `programs.ssh.knownHostsFiles`. This setting could be improved by making it a list of files that are checked in order, but for now I think it's enough.

 - Allow obtaining private keys via a command instead of the ssh agent
Instead of an ssh agent, I use Bitwarden to store my ssh keys and [rbw](https://github.com/doy/rbw) to access them on the command line. I've used `memfd_create` to store the key in a volatile anonymous file for automatic cleanup.
 
 - Add partial support for the `NIX_SSHOPTS` environment variable
Setting this is necessary to support passing the private keys obtained via `ssh.private_key_cmd` to the `ssh` command run by `nix-copy-closure`. So adding support for users to set it directly seems natural. It's not full support since it's only used with `nix-copy-closure`.