### PR TITLE
fix(apply): minor logging fixes

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -474,10 +474,6 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			log.Errorf("failed to build configuration: %v", err)
 			return err
 		}
-
-		if opts.NoActivate && opts.NoBoot && !dryBuild {
-			log.Infof("the built configuration is %v", resultLocation)
-		}
 	} else {
 		resultLocation = opts.StorePath
 	}
@@ -518,6 +514,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	case *configuration.SystemBuild:
 		if dryBuild {
 			log.Debugf("this is a dry build, no activation will be performed")
+		} else if opts.NoActivate && opts.NoBoot {
+			log.Infof("the built configuration is %v", resultLocation)
 		}
 
 		if !v.Activate {

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -397,6 +397,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		switch buildType.(type) {
 		case *configuration.SystemBuild:
 			log.Step("Building configuration...")
+		case *configuration.ImageBuild:
+			log.Step("Building image...")
 		case *configuration.VMBuild:
 			log.Step("Building VM...")
 		}


### PR DESCRIPTION
- fix(apply) add log step for building an image
  This makes it consistent with system and vm builds.

- fix(apply): only log built config when building a system
  To avoid displaying the built store path twice with image and vm builds.
