### PR TITLE
refactor(system): make root cmd+flags a property of the command struct

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -716,7 +716,7 @@ func upgradeChannels(s system.CommandRunner, opts *upgradeChannelsOptions) error
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.RunAsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootCommand)
 	}
 	_, err := s.Run(cmd)
 	return err

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -120,7 +120,7 @@ func AddNewNixProfile(s system.System, profile string, closure string, opts *Add
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.RunAsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootCommand)
 	}
 
 	_, err := s.Run(cmd)
@@ -148,7 +148,7 @@ func SetNixProfileGeneration(s system.System, profile string, genNumber uint64, 
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.RunAsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootCommand)
 	}
 
 	_, err := s.Run(cmd)
@@ -251,7 +251,7 @@ func SwitchToConfiguration(s system.CommandRunner, generationLocation string, ac
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.RunAsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootCommand)
 	}
 
 	if opts.InstallBootloader {

--- a/internal/system/local.go
+++ b/internal/system/local.go
@@ -28,7 +28,18 @@ func (l *LocalSystem) FS() Filesystem {
 }
 
 func (l *LocalSystem) Run(cmd *Command) (int, error) {
-	command := exec.Command(cmd.Name, cmd.Args...)
+	var commandName string
+	var args []string
+
+	if cmd.RootElevationCmd != "" {
+		commandName = cmd.RootElevationCmd
+		args = append([]string{cmd.Name}, cmd.Args...)
+	} else {
+		commandName = cmd.Name
+		args = cmd.Args
+	}
+
+	command := exec.Command(commandName, args...)
 
 	command.Stdout = cmd.Stdout
 	command.Stderr = cmd.Stderr


### PR DESCRIPTION
When running SSH commands with a root elevation command like `sudo`, this didn't quite work in all cases when passing environment variables. That is because the root command was simply getting replaced in the command's `Name` string and `Args` slice, rather than being treated specially.

This resulted in invocations of `sh -c "export VAR=value; set -- <root cmd flags> <args>; sudo exec $@"`, which ended up wiping the set environment variables after elevation, rather than `sudo <root cmd flags> sh -c "export VAR=value; set -- <args>; exec $@"`, which would preserve the set variables like `VAR` through SSH and through the root command env var sanitation process.

This PR refactors the root command and possible root command flags into specific `Command` fields so that this distinction can be made when creating the shell wrapper on SSH systems to preserve env vars.

Closes #180.