### PR TITLE
fix(system): use wrapper for local env when necessary

### DIFF
--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -259,6 +259,9 @@ func SwitchToConfiguration(s system.CommandRunner, generationLocation string, ac
 	}
 
 	cmd.SetEnv("NIXOS_CLI_ATTEMPTING_ACTIVATION", "1")
+
+	cmd.InheritEnv("NIXOS_NO_CHECK")
+
 	_, err := s.Run(cmd)
 	return err
 }

--- a/internal/system/local.go
+++ b/internal/system/local.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -37,6 +38,10 @@ func (l *LocalSystem) Run(cmd *Command) (int, error) {
 	} else {
 		commandName = cmd.Name
 		args = cmd.Args
+	}
+
+	if len(args) == 0 {
+		return 0, fmt.Errorf("command has empty argument list")
 	}
 
 	command := exec.Command(commandName, args...)

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -1,12 +1,16 @@
 package system
 
 import (
+	"errors"
 	"io"
 	"maps"
 	"os"
 	"slices"
+	"sort"
+	"strings"
 
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/utils"
 )
 
 type CommandRunner interface {
@@ -67,4 +71,88 @@ func (c *Command) Clone() *Command {
 		RootElevationCmd:      c.RootElevationCmd,
 		RootElevationCmdFlags: rootElevationCmdFlags,
 	}
+}
+
+// Build a safe `sh -c` wrapper that can support setting
+// environment variables for a process inline.
+//
+// This is required for environments that sanitize environment
+// variables, such as when commands are ran using `sudo` or other
+// root elevation commands, or running commands on systems using
+// SSH without proper AcceptEnv settings configured.
+func (c *Command) BuildShellWrapper() ([]string, error) {
+	// Make sure all passed arguments and env vars
+	// do not have any NUL bytes and have valid names.
+	if strings.IndexByte(c.Name, 0) != -1 {
+		return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
+	}
+
+	if strings.IndexByte(c.RootElevationCmd, 0) != -1 {
+		return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
+	}
+
+	for _, a := range c.Args {
+		if strings.IndexByte(a, 0) != -1 {
+			return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
+		}
+	}
+
+	for _, a := range c.RootElevationCmdFlags {
+		if strings.IndexByte(a, 0) != -1 {
+			return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
+		}
+	}
+
+	for k, v := range c.Env {
+		if !envVarNamePattern.MatchString(k) {
+			return nil, errors.New("invalid env var name: " + k)
+		}
+		if strings.IndexByte(v, 0) != -1 {
+			return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
+		}
+	}
+
+	// Use deterministic ordering for env exports,
+	// by alphabetical order
+	keys := make([]string, 0, len(c.Env))
+	for k := range c.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Start building the command string; first, all variables
+	// get exported inline.
+	var b strings.Builder
+	for _, k := range keys {
+		q := utils.Quote(c.Env[k])
+		b.WriteString("export ")
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(q)
+		b.WriteString("; ")
+	}
+
+	// Set positional parameters to the passed args,
+	// and execute them inline using `exec`.
+	b.WriteString("set -- ")
+	b.WriteString(utils.Quote(c.Name))
+	for _, a := range c.Args {
+		q := utils.Quote(a)
+		b.WriteByte(' ')
+		b.WriteString(q)
+	}
+	b.WriteString(`; exec "$@"`)
+
+	wrappedCmdScript := b.String()
+
+	var argv []string
+	if c.RootElevationCmd != "" {
+		// Root elevation commands/flags must go BEFORE the `sh` invocation.
+		// This will ensure that the environment is preserved across the
+		// elevation boundary.
+		argv = append([]string{c.RootElevationCmd}, c.RootElevationCmdFlags...)
+	}
+	argv = append(argv, "sh", "-c", wrappedCmdScript)
+
+	return argv, nil
 }

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -44,6 +44,10 @@ func NewCommand(name string, args ...string) *Command {
 }
 
 func (c *Command) SetEnv(key string, value string) {
+	if c.Env == nil {
+		c.Env = make(map[string]string)
+	}
+
 	c.Env[key] = value
 }
 
@@ -178,4 +182,21 @@ func (c *Command) BuildArgs() []string {
 	argv = append(argv, c.Args...)
 
 	return argv
+}
+
+// Inherit the passed environment variables' values explicitly
+// into the command's env map.
+//
+// Useful when passing variables over `sudo` or SSH environment
+// variable sanitation barriers.
+func (c *Command) InheritEnv(vars ...string) {
+	if c.Env == nil {
+		c.Env = make(map[string]string)
+	}
+
+	for _, name := range vars {
+		if value, set := os.LookupEnv(name); set {
+			c.Env[name] = value
+		}
+	}
 }

--- a/internal/system/runner_test.go
+++ b/internal/system/runner_test.go
@@ -1,0 +1,136 @@
+package system
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildShellWrapper_NoEnv_NoRoot(t *testing.T) {
+	cmd := NewCommand("echo", "hello", "world")
+
+	argv, err := cmd.BuildShellWrapper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(argv) != 3 {
+		t.Fatalf("expected 3 args (sh -c script), got %d: %#v", len(argv), argv)
+	}
+
+	if argv[0] != "sh" || argv[1] != "-c" {
+		t.Fatalf("expected sh -c prefix, got: %#v", argv[:2])
+	}
+
+	script := argv[2]
+
+	if !strings.Contains(script, `set --`) {
+		t.Fatalf("expected script to contain 'set --', got: %s", script)
+	}
+
+	if !strings.Contains(script, `exec "$@"`) {
+		t.Fatalf("expected script to exec \"$@\", got: %s", script)
+	}
+
+	if !strings.Contains(script, "echo") {
+		t.Fatalf("expected script to contain command name, got: %s", script)
+	}
+}
+
+func TestBuildShellWrapper_WithEnv_DeterministicOrder(t *testing.T) {
+	cmd := NewCommand("true")
+	cmd.SetEnv("B", "2")
+	cmd.SetEnv("A", "1")
+
+	argv, err := cmd.BuildShellWrapper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	script := argv[2]
+
+	aIndex := strings.Index(script, "export A=")
+	bIndex := strings.Index(script, "export B=")
+
+	if aIndex == -1 || bIndex == -1 {
+		t.Fatalf("expected exports for A and B, got: %s", script)
+	}
+
+	if aIndex > bIndex {
+		t.Fatalf("expected env vars sorted alphabetically, got: %s", script)
+	}
+}
+
+func TestBuildShellWrapper_InvalidEnvName(t *testing.T) {
+	cmd := NewCommand("true")
+	cmd.SetEnv("INVALID-NAME", "value")
+
+	_, err := cmd.BuildShellWrapper()
+	if err == nil {
+		t.Fatalf("expected error for invalid env name")
+	}
+
+	if !strings.Contains(err.Error(), "invalid env var name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildShellWrapper_NulInEnvValue(t *testing.T) {
+	cmd := NewCommand("true")
+	cmd.SetEnv("VALID", "bad\x00value")
+
+	_, err := cmd.BuildShellWrapper()
+	if err == nil {
+		t.Fatalf("expected error for NUL byte in env value")
+	}
+}
+
+func TestBuildShellWrapper_NulInArgs(t *testing.T) {
+	cmd := NewCommand("echo", "bad\x00arg")
+
+	_, err := cmd.BuildShellWrapper()
+	if err == nil {
+		t.Fatalf("expected error for NUL byte in arg")
+	}
+}
+
+func TestBuildShellWrapper_WithRootElevation(t *testing.T) {
+	cmd := NewCommand("id")
+	cmd.AsRoot("sudo", "-n")
+
+	argv, err := cmd.BuildShellWrapper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(argv) < 4 {
+		t.Fatalf("expected root elevation prefix, got: %#v", argv)
+	}
+
+	if argv[0] != "sudo" || argv[1] != "-n" {
+		t.Fatalf("expected sudo -n prefix, got: %#v", argv[:2])
+	}
+
+	if argv[2] != "sh" || argv[3] != "-c" {
+		t.Fatalf("expected sh -c after root prefix, got: %#v", argv)
+	}
+}
+
+func TestBuildShellWrapper_EnvAndArgsProperlyQuoted(t *testing.T) {
+	cmd := NewCommand("echo", `hello world`, `foo"bar`)
+	cmd.SetEnv("TEST", `value with spaces`)
+
+	argv, err := cmd.BuildShellWrapper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	script := argv[2]
+
+	if !strings.Contains(script, "export TEST=") {
+		t.Fatalf("missing export statement: %s", script)
+	}
+
+	if !strings.Contains(script, "hello world") {
+		t.Fatalf("expected quoted arg with space present: %s", script)
+	}
+}


### PR DESCRIPTION
The current wrapper for setting variables through SSH env var sanitation barriers works pretty well in that instance, but needed to be expanded to work with local systems so that it can pass through `sudo`/other root escalation barriers as well, since those tend to sanitize the environment variables for the subprocess they run.

As such, this PR adds tests for the now-exported shell wrapper builder, and makes all systems use it when environment variables need to be passed through these barriers. I added an extra method to inherit environment variables explicitly when necessary as well, although this does need to be done on a per-process and opt-in basis, since I do not want to risk breaking subcommand invariants when they are invoked through `sudo` (i.e. `sudo` rewrites the HOME of the process to be `/root`, so we shouldn't preserve that; things like that that are more of a hassle to maintain than just opting-in to env var preservation).

Closes #180, for real this time hopefully.