### PR TITLE
fix(apply): suppress gc root warning from legacy build commands

### DIFF
--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -232,7 +232,7 @@ func (f *FlakeRef) buildRemoteSystem(s *system.SSHSystem, buildType BuildType, o
 	// 3. Realise the copied drv on the builder.
 	// $ nix-store -r "$drv" "${buildArgs[@]}"
 
-	realiseDrvArgv := []string{"nix-store", "-r", drvPath}
+	realiseDrvArgv := []string{"nix-store", "--no-gc-warning", "-r", drvPath}
 	realiseDrvArgv = append(realiseDrvArgv, realiseArgs...)
 
 	if opts.ResultLocation != "" {

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -206,7 +206,7 @@ func (l *LegacyConfiguration) buildRemoteSystem(s *system.SSHSystem, buildType B
 
 	// 1. Determine the drv path.
 	// Equivalent of `nix-instantiate -A "${attr}" ${extraBuildFlags[@]}`
-	instantiateArgv := []string{"nix-instantiate", l.ConfigPathArg(), "-A", l.BuildAttr(buildType.BuildAttr())}
+	instantiateArgv := []string{"nix-instantiate", "--no-gc-warning", l.ConfigPathArg(), "-A", l.BuildAttr(buildType.BuildAttr())}
 	instantiateArgv = append(instantiateArgv, extraInstantiateArgs...)
 
 	var drvPathBuf bytes.Buffer
@@ -233,7 +233,7 @@ func (l *LegacyConfiguration) buildRemoteSystem(s *system.SSHSystem, buildType B
 
 	// 3. Realise the copied drv on the builder.
 	// $ nix-store -r "$drv" "${buildArgs[@]}"
-	realiseArgv := []string{"nix-store", "-r", drvPath}
+	realiseArgv := []string{"nix-store", "--no-gc-warning", "-r", drvPath}
 	realiseArgv = append(realiseArgv, extraRealiseArgs...)
 
 	// Mimic `nixos-rebuild` behavior of using -k option


### PR DESCRIPTION
Both `nix-store` and `nix-instantiate` display a warning when `--add-root` is not passed. Suppress it by passing `--no-gc-warning`.

Initially, I only added the flag when `opts.ResultLocation` was unset, but adding the flag at the end results in a weird error from `nix-store`. So I simply added it unconditionally, as it still works when `--add-root` is also specified (it just doesn't do anything).