### PR TITLE
revert: use explicit go version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,8 @@
         };
 
         devShells = let
-          inherit (pkgs) go golangci-lint mkShell mdbook scdoc govulncheck prettier;
+          inherit (pkgs) golangci-lint mkShell mdbook scdoc govulncheck prettier;
+          go = pkgs.go_1_26;
         in {
           default = mkShell {
             name = "nixos-shell";

--- a/nix/package/unwrapped.nix
+++ b/nix/package/unwrapped.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  buildGoModule,
+  buildGo126Module,
   installShellFiles,
   stdenv,
   scdoc,
   revision ? "unknown",
   flake ? true,
 }:
-buildGoModule (finalAttrs: {
+buildGo126Module (finalAttrs: {
   pname = "nixos-cli-unwrapped";
   version = "0.16.0-dev";
 


### PR DESCRIPTION
This reverts commit 52a2170b32c0a2530e953ad784950b128b5ad041.

Closes #213.