### PR TITLE
ci: move vuln checks to a cronjob

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,3 @@ jobs:
 
       - name: Build docs
         run: nix develop .# -c make gen-docs
-
-      - name: Check for vulns
-        run: nix develop .# -c make vuln-check

--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -1,0 +1,26 @@
+name: Check for vulnerabilities
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Saturday @ 12:00 PM UTC
+    - cron: '0 12 * * 6'
+
+jobs:
+  vuln-check:
+    name: Check for vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Initialize Cachix
+        uses: cachix/cachix-action@v14
+        with:
+          name: watersucks
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Run checks
+        run: nix develop .# -c make vuln-check


### PR DESCRIPTION
Vulnerability checking with `govulncheck` is impure and has caused otherwise-successful CI checks to fail at seemingly random intervals.

To prevent blockers in the future, this will now be ran on a weekly basis and will not be a prerequisite for merging.