### PR TITLE
feat(nixopts): display nix options in completion output

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -324,6 +324,7 @@ Check the man page nixos-cli-apply(1) for more details on what options are avail
 
 	cmdUtils.SetHelpFlagText(&cmd)
 	cmd.SetHelpTemplate(helpTemplate)
+	cmdUtils.SetUsageHideNixFlags(&cmd)
 
 	return &cmd
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -189,11 +189,12 @@ Arguments:
 	}
 	helpTemplate += `
 This command also forwards Nix options passed here to all relevant Nix invocations.
-Check the Nix manual page for more details on what options are available.
+Check the man page nixos-cli-install(1) for more details on what options are available.
 `
 
 	cmd.SetHelpTemplate(helpTemplate)
 	cmdUtils.SetHelpFlagText(&cmd)
+	cmdUtils.SetUsageHideNixFlags(&cmd)
 
 	return &cmd
 }

--- a/internal/cmd/nixopts/nixopts.go
+++ b/internal/cmd/nixopts/nixopts.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const NixFlagAnnotation = "nixos_cli_nix_flag"
+
 func addNixOptionBool(cmd *cobra.Command, dest *bool, name string, shorthand string, desc string) {
 	flag := string(name)
 	if shorthand != "" {
@@ -16,7 +18,7 @@ func addNixOptionBool(cmd *cobra.Command, dest *bool, name string, shorthand str
 	} else {
 		cmd.Flags().BoolVar(dest, flag, false, desc)
 	}
-	cmd.Flags().Lookup(flag).Hidden = true
+	_ = cmd.Flags().SetAnnotation(flag, NixFlagAnnotation, nil)
 }
 
 // func addNixOptionInt(cmd *cobra.Command, dest *int, name string, shorthand string, desc string) {
@@ -36,7 +38,7 @@ func addNixOptionString(cmd *cobra.Command, dest *string, name string, shorthand
 	} else {
 		cmd.Flags().StringVar(dest, flag, "", desc)
 	}
-	cmd.Flags().Lookup(flag).Hidden = true
+	_ = cmd.Flags().SetAnnotation(flag, NixFlagAnnotation, nil)
 }
 
 func addNixOptionStringSlice(cmd *cobra.Command, dest *[]string, name string, shorthand string, desc string) {
@@ -46,7 +48,7 @@ func addNixOptionStringSlice(cmd *cobra.Command, dest *[]string, name string, sh
 	} else {
 		cmd.Flags().StringSliceVar(dest, flag, nil, desc)
 	}
-	cmd.Flags().Lookup(flag).Hidden = true
+	_ = cmd.Flags().SetAnnotation(flag, NixFlagAnnotation, nil)
 }
 
 func addNixOptionStringMap(cmd *cobra.Command, dest *map[string]string, name string, shorthand string, desc string) {
@@ -56,7 +58,7 @@ func addNixOptionStringMap(cmd *cobra.Command, dest *map[string]string, name str
 	} else {
 		cmd.Flags().StringToStringVar(dest, flag, nil, desc)
 	}
-	cmd.Flags().Lookup(flag).Hidden = true
+	_ = cmd.Flags().SetAnnotation(flag, NixFlagAnnotation, nil)
 }
 
 func addNixOptionVar(cmd *cobra.Command, dest pflag.Value, name string, shorthand string, desc string) {
@@ -66,7 +68,7 @@ func addNixOptionVar(cmd *cobra.Command, dest pflag.Value, name string, shorthan
 	} else {
 		cmd.Flags().Var(dest, flag, desc)
 	}
-	cmd.Flags().Lookup(flag).Hidden = true
+	_ = cmd.Flags().SetAnnotation(flag, NixFlagAnnotation, nil)
 }
 
 type NixCommand string

--- a/internal/cmd/utils/utils.go
+++ b/internal/cmd/utils/utils.go
@@ -9,11 +9,31 @@ import (
 	"sort"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nix-community/nixos-cli/internal/cmd/nixopts"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func SetHelpFlagText(cmd *cobra.Command) {
 	cmd.Flags().BoolP("help", "h", false, "Show this help menu")
+}
+
+// Set a usage function that hides any nix flags before returning
+// the default usage function. This is needed as hiding the flags
+// outside of the usage function also hides them from completion
+// output.
+func SetUsageHideNixFlags(cmd *cobra.Command) {
+	defaultUsageFunc := cmd.UsageFunc()
+
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if _, ok := f.Annotations[nixopts.NixFlagAnnotation]; ok {
+				f.Hidden = true
+			}
+		})
+
+		return defaultUsageFunc(cmd)
+	})
 }
 
 var ErrCommand = errors.New("command error")


### PR DESCRIPTION
~~- Annotate nix flags and introduce a custom usage function to display them in a dedicated section.~~
~~- Stop hiding nix flags so they show up in completion menus.~~
~~- Remove the default value text for StringMap options.~~
~~- Set a back-quoted name for StringMap options to replace the unclear default of "stringToString".~~

~~Though it makes discovering the available nix options much more natural, I'm still not entirely sure this is worth bloating the usage text and completions.~~

Edit:
- Stop hiding nix flags so they show up in completion output.
- Since they would otherwise be visible in the usage text, annotate
      nix flags and introduce a custom usage function to hide them from
      the usage text.
