### PR TITLE
feat(ssh): support ssh-ng hosts when copying closures

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -674,8 +674,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	}
 
 	if !dryBuild {
-		copyFlags := opts.NixOptions.ArgsForCommand(nixopts.CmdCopyClosure)
-		err = system.CopyClosures(buildHost, targetHost, []string{resultLocation}, copyFlags...)
+		err = system.CopyClosures(buildHost, targetHost, []string{resultLocation}, &opts.NixOptions)
 		if err != nil {
 			log.Errorf("failed to copy system closure to target host: %v", err)
 			return err

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -118,7 +118,10 @@ command tree. See *nixos-cli-generation(1)* for details.
 	to perform the build. The host needs to be accessible with SSH, and must be
 	able to perform Nix builds.
 
-	*HOST* is a simple SSH address with the format "_user@address:port_".
+	*HOST* is a simple SSH address with the format "_user@address:port_". This
+	can be prefixed with "_ssh-ng://_" or "_ssh://_" to indicate the Nix store
+	protocol to use when copying closures. Using _ssh-ng_ requires having the
+	_nix-command_ Nix experimental feature enabled.
 
 	SSH can be authenticated using private keys via the following methods:
 	- the *ssh.private_key_cmd* setting (see *nixos-cli-settings(5)*)
@@ -286,7 +289,10 @@ command tree. See *nixos-cli-generation(1)* for details.
 
 	If this is left empty, activation of the system will happen locally.
 
-	*HOST* is a simple SSH address with the format "_user@address:port_".
+	*HOST* is a simple SSH address with the format "_user@address:port_". This
+	can be prefixed with "_ssh-ng://_" or "_ssh://_" to indicate the Nix store
+	protocol to use when copying closures. Using _ssh-ng_ requires having the
+	_nix-command_ Nix experimental feature enabled.
 
 	If *--build-host* is not explicitly specified or is left empty, building
 	will take place locally.

--- a/internal/cmd/nixopts/nixopts.go
+++ b/internal/cmd/nixopts/nixopts.go
@@ -74,12 +74,13 @@ func addNixOptionVar(cmd *cobra.Command, dest pflag.Value, name string, shorthan
 type NixCommand string
 
 const (
-	CmdBuild        = "nix build"
-	CmdLegacyBuild  = "nix-build"
-	CmdCopyClosure  = "nix-copy-closure"
-	CmdEval         = "nix eval"
-	CmdInstantiate  = "nix-instantiate"
-	CmdStoreRealise = "nix-store-realise"
+	CmdBuild        NixCommand = "nix build"
+	CmdLegacyBuild  NixCommand = "nix-build"
+	CmdCopyClosure  NixCommand = "nix-copy-closure"
+	CmdCopy         NixCommand = "nix copy"
+	CmdEval         NixCommand = "nix eval"
+	CmdInstantiate  NixCommand = "nix-instantiate"
+	CmdStoreRealise NixCommand = "nix-store-realise"
 )
 
 type NixOption interface {
@@ -104,7 +105,7 @@ func (q *Quiet) Bind(cmd *cobra.Command) {
 
 func (Quiet) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdCopy, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -127,7 +128,7 @@ func (p *PrintBuildLogs) Bind(cmd *cobra.Command) {
 
 func (PrintBuildLogs) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -173,7 +174,7 @@ func (s *ShowTrace) Bind(cmd *cobra.Command) {
 
 func (ShowTrace) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -196,7 +197,7 @@ func (k *KeepGoing) Bind(cmd *cobra.Command) {
 
 func (KeepGoing) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -219,7 +220,7 @@ func (k *KeepFailed) Bind(cmd *cobra.Command) {
 
 func (KeepFailed) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -242,7 +243,7 @@ func (f *Fallback) Bind(cmd *cobra.Command) {
 
 func (Fallback) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -265,7 +266,7 @@ func (r *Refresh) Bind(cmd *cobra.Command) {
 
 func (Refresh) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdCopy, CmdBuild, CmdEval:
 		return true
 	default:
 		return false
@@ -288,7 +289,7 @@ func (r *Repair) Bind(cmd *cobra.Command) {
 
 func (Repair) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -311,7 +312,7 @@ func (i *Impure) Bind(cmd *cobra.Command) {
 
 func (Impure) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdEval, CmdInstantiate:
+	case CmdBuild, CmdCopy, CmdLegacyBuild, CmdEval, CmdInstantiate:
 		return true
 	default:
 		return false
@@ -334,7 +335,7 @@ func (o *Offline) Bind(cmd *cobra.Command) {
 
 func (Offline) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdCopy, CmdBuild, CmdEval:
 		return true
 	default:
 		return false
@@ -357,7 +358,7 @@ func (n *NoNet) Bind(cmd *cobra.Command) {
 
 func (NoNet) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdCopy, CmdBuild, CmdEval:
 		return true
 	default:
 		return false
@@ -383,7 +384,7 @@ func (m *MaxJobs) Bind(cmd *cobra.Command) {
 
 func (MaxJobs) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -429,7 +430,7 @@ func (c *Cores) Bind(cmd *cobra.Command) {
 
 func (Cores) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -475,7 +476,7 @@ func (b *Builders) Bind(cmd *cobra.Command) {
 
 func (Builders) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -514,7 +515,7 @@ func (l *LogFormat) Bind(cmd *cobra.Command) {
 
 func (LogFormat) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -541,7 +542,7 @@ func (i *Include) Bind(cmd *cobra.Command) {
 
 func (Include) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdEval, CmdInstantiate:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdEval, CmdInstantiate:
 		return true
 	default:
 		return false
@@ -571,7 +572,7 @@ func (o *Option) Bind(cmd *cobra.Command) {
 
 func (Option) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdLegacyBuild, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
+	case CmdBuild, CmdLegacyBuild, CmdCopy, CmdCopyClosure, CmdEval, CmdInstantiate, CmdStoreRealise:
 		return true
 	default:
 		return false
@@ -603,7 +604,7 @@ func (s *SubstituteOnDestination) Bind(cmd *cobra.Command) {
 
 func (SubstituteOnDestination) Supports(c NixCommand) bool {
 	switch c {
-	case CmdCopyClosure:
+	case CmdCopy, CmdCopyClosure:
 		return true
 	default:
 		return false
@@ -626,7 +627,7 @@ func (r *RecreateLockFile) Bind(cmd *cobra.Command) {
 
 func (RecreateLockFile) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -649,7 +650,7 @@ func (n *NoUpdateLockFile) Bind(cmd *cobra.Command) {
 
 func (NoUpdateLockFile) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -672,7 +673,7 @@ func (n *NoWriteLockFile) Bind(cmd *cobra.Command) {
 
 func (NoWriteLockFile) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -697,7 +698,7 @@ func (n *NoUseRegistries) Bind(cmd *cobra.Command) {
 
 func (NoUseRegistries) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -720,7 +721,7 @@ func (c *CommitLockFile) Bind(cmd *cobra.Command) {
 
 func (CommitLockFile) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -743,7 +744,7 @@ func (u *UpdateInput) Bind(cmd *cobra.Command) {
 
 func (UpdateInput) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false
@@ -780,7 +781,7 @@ func (o *OverrideInput) Bind(cmd *cobra.Command) {
 
 func (OverrideInput) Supports(c NixCommand) bool {
 	switch c {
-	case CmdBuild, CmdEval:
+	case CmdBuild, CmdCopy, CmdEval:
 		return true
 	default:
 		return false

--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -239,12 +239,7 @@ func (f *FlakeRef) buildRemoteSystem(s *system.SSHSystem, buildType BuildType, o
 	// 2. Copy the drv path over to the builder.
 	// $ nix "${flakeFlags[@]}" copy "${copyFlags[@]}" --derivation --to "ssh://$buildHost" "$drv"
 
-	var copyFlags []string
-	if opts.NixOpts != nil {
-		copyFlags = opts.NixOpts.ArgsForCommand(nixopts.CmdCopyClosure)
-	}
-
-	if err = system.CopyClosures(localSystem, s, []string{drvPath}, copyFlags...); err != nil {
+	if err = system.CopyClosures(localSystem, s, []string{drvPath}, opts.NixOpts); err != nil {
 		return "", fmt.Errorf("failed to copy drv to build host: %v", err)
 	}
 

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -244,7 +244,7 @@ func (l *LegacyConfiguration) buildRemoteSystem(s *system.SSHSystem, buildType B
 
 	// 2. Copy the drv path over to the builder.
 	// $ nix-copy-closure --to "$buildHost" "$drv"
-	if err := system.CopyClosures(localSystem, s, []string{drvPath}); err != nil {
+	if err := system.CopyClosures(localSystem, s, []string{drvPath}, opts.NixOpts); err != nil {
 		return "", fmt.Errorf("failed to copy drv to build host: %v", err)
 	}
 

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -45,10 +45,19 @@ type SSHConfig struct {
 	HostKeyVerification settings.HostKeyVerificationType
 	KnownHostsFiles     []string
 
+	StoreType NixStoreType
+
 	password []byte
 
 	agentManager *sshUtils.AgentManager
 }
+
+type NixStoreType string
+
+const (
+	NixStoreTypeSSH   NixStoreType = "ssh"
+	NixStoreTypeSSHNG NixStoreType = "ssh-ng"
+)
 
 type SSHConfigOptions struct {
 	AgentManager        *sshUtils.AgentManager
@@ -67,9 +76,17 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 		return nil, errors.New("options.HostKeyVerification is empty")
 	}
 
+	storeType := NixStoreTypeSSH
+
+	var after string
+	var ok bool
+
 	// Parse the user@address:port SSH host string
-	if after, ok := strings.CutPrefix(host, "ssh://"); ok {
+	if after, ok = strings.CutPrefix(host, "ssh://"); ok {
 		host = after
+	} else if after, ok = strings.CutPrefix(host, "ssh-ng://"); ok {
+		host = after
+		storeType = NixStoreTypeSSHNG
 	}
 
 	hostInfo, err := sshUtils.ParseUserHostPort(host)
@@ -146,6 +163,8 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 		User:    username,
 		Address: address,
 		Port:    port,
+
+		StoreType: storeType,
 	}
 
 	// Use password auth to access the SSH system with
@@ -659,6 +678,10 @@ func (s *SSHSystem) IsNixOS() bool {
 	}
 
 	return nixosDistroIDRegex.MatchString(distroID)
+}
+
+func (s *SSHSystem) AddressWithScheme() string {
+	return fmt.Sprintf("%s://%s@%s:%d", s.cfg.StoreType, s.cfg.User, s.cfg.Address, s.cfg.Port)
 }
 
 func (s *SSHSystem) Address() string {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,10 +1,10 @@
 package system
 
 import (
-	"fmt"
-	"os"
+	"bytes"
+	"strings"
 
-	shlex "github.com/carapace-sh/carapace-shlex"
+	"github.com/nix-community/nixos-cli/internal/cmd/nixopts"
 	"github.com/nix-community/nixos-cli/internal/logger"
 )
 
@@ -17,7 +17,7 @@ type System interface {
 
 // Invoke the `nix-copy-closure` command to copy between two types of
 // systems.
-func CopyClosures(src System, dest System, paths []string, extraArgs ...string) error {
+func CopyClosures(src System, dest System, paths []string, extraNixOpts nixopts.NixOptionsSet) error {
 	log := src.Logger()
 
 	if len(paths) == 0 {
@@ -25,22 +25,11 @@ func CopyClosures(src System, dest System, paths []string, extraArgs ...string) 
 		return nil
 	}
 
-	argv := []string{"nix-copy-closure"}
+	commandRunner := NewLocalSystem(log)
 
-	var nixSSHOpts []string
-	nixSSHOptsEnv := os.Getenv("NIX_SSHOPTS")
-	if nixSSHOptsEnv != "" {
-		nixSSHOptsTokens, err := shlex.Split(nixSSHOptsEnv)
-		if err != nil {
-			return fmt.Errorf("failed to parse NIX_SSHOPTS: %v", err)
-		}
-		nixSSHOpts = nixSSHOptsTokens.Strings()
-	}
+	nixCopySupported := checkNixCommandSupport(commandRunner)
 
-	srcIsRemote := src.IsRemote()
-	destIsRemote := dest.IsRemote()
-
-	var commandRunner CommandRunner
+	var argv []string
 
 	// All type asserts must work here, otherwise the IsRemote() method is
 	// implemented incorrectly for a given platform or the conditions are
@@ -48,40 +37,64 @@ func CopyClosures(src System, dest System, paths []string, extraArgs ...string) 
 	//
 	// There are/will be no other system types implemented, so casting
 	// directly is fine here.
-	if srcIsRemote && destIsRemote {
+	if src.IsRemote() && dest.IsRemote() {
 		// remote -> remote, so treat the source as a store and use the local
 		// machine as the command runner.
 		//
 		// This should either be running as a trusted user or as root, so
 		// remote store access should exist.
-		commandRunner = NewLocalSystem(log)
-		srcAddr := src.(*SSHSystem).Address()
-		destAddr := dest.(*SSHSystem).Address()
-		if srcAddr == destAddr {
+		src := src.(*SSHSystem)
+		dest := dest.(*SSHSystem)
+
+		if src.Address() == dest.Address() {
 			log.Debugf("remotes have the same address, skipping copy")
 			return nil
 		}
-		srcArg := fmt.Sprintf("ssh://%s", srcAddr)
-		argv = append(argv, "--store", srcArg, "--to", destAddr)
-	} else if srcIsRemote && !destIsRemote {
-		// remote -> local, so use --from and run on the local host (dest), since there
-		// is no reliable way to run this on the remote while determining how
-		// the local address appears to it.
-		commandRunner = dest
-		srcAddr := src.(*SSHSystem).Address()
-		argv = append(argv, "--from", srcAddr)
-	} else if !srcIsRemote && destIsRemote {
-		// local -> remote, so run this command on the local host.
-		commandRunner = src
-		destAddr := dest.(*SSHSystem).Address()
-		argv = append(argv, "--to", destAddr)
+
+		if nixCopySupported {
+			argv = []string{"nix", "copy", "--from", src.AddressWithScheme(), "--to", dest.AddressWithScheme()}
+		} else {
+			argv = []string{"nix-copy-closure", "--store", src.AddressWithScheme(), "--to", dest.Address()}
+			if src.cfg.StoreType == NixStoreTypeSSHNG || dest.cfg.StoreType == NixStoreTypeSSHNG {
+				log.Warn("the ssh-ng store type is only partially supported in legacy mode")
+			}
+		}
+	} else if src.IsRemote() {
+		// remote -> local
+		src := src.(*SSHSystem)
+		if nixCopySupported {
+			argv = []string{"nix", "copy", "--from", src.AddressWithScheme()}
+		} else {
+			argv = []string{"nix-copy-closure", "--from", src.Address()}
+			if src.cfg.StoreType == NixStoreTypeSSHNG {
+				log.Warn("the ssh-ng store type is only partially supported in legacy mode")
+			}
+		}
+	} else if dest.IsRemote() {
+		// local -> remote
+		dest := dest.(*SSHSystem)
+		if nixCopySupported {
+			argv = []string{"nix", "copy", "--to", dest.AddressWithScheme()}
+		} else {
+			argv = []string{"nix-copy-closure", "--to", dest.Address()}
+			if dest.cfg.StoreType == NixStoreTypeSSHNG {
+				log.Warn("the ssh-ng store type is only partially supported in legacy mode")
+			}
+		}
 	} else {
 		// local -> local, no-op
 		log.Debugf("both systems are local, skipping copy")
 		return nil
 	}
 
-	argv = append(argv, extraArgs...)
+	if extraNixOpts != nil {
+		cmdToUse := nixopts.CmdCopyClosure
+		if nixCopySupported {
+			cmdToUse = nixopts.CmdCopy
+		}
+		argv = append(argv, extraNixOpts.ArgsForCommand(cmdToUse)...)
+	}
+
 	if log.GetLogLevel() == logger.LogLevelDebug {
 		argv = append(argv, "-v")
 	}
@@ -91,10 +104,24 @@ func CopyClosures(src System, dest System, paths []string, extraArgs ...string) 
 	log.CmdArray(argv)
 
 	cmd := NewCommand(argv[0], argv[1:]...)
-	nixSSHOptsEnv = shlex.Join(nixSSHOpts)
-	if nixSSHOptsEnv != "" {
-		cmd.SetEnv("NIX_SSHOPTS", nixSSHOptsEnv)
-	}
+
+	cmd.InheritEnv("NIX_SSHOPTS")
+
 	_, err := commandRunner.Run(cmd)
 	return err
+}
+
+func checkNixCommandSupport(s System) bool {
+	checkSupportCmd := NewCommand("nix", "config", "show", "experimental-features")
+
+	var stdout bytes.Buffer
+	checkSupportCmd.Stdout = &stdout
+	checkSupportCmd.Stderr = nil
+
+	_, err := s.Run(checkSupportCmd)
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(stdout.String(), "nix-command")
 }


### PR DESCRIPTION
This PR adds support for Nix's `ssh-ng` protocol when copying closures to/from hosts in `nixos apply`.

`--build-host`/`--target-host` can now prefix their host arguments with `ssh-ng://` by using `ssh-ng://user@host:port`.

Currently, if `nix config show experimental-features` fails or does not have `nix-command` in it, it will fall back to `nix-copy-closures` instead of using `nix copy`. Otherwise, `nix copy` is always used to facilitate `ssh-ng` host usage.

Closes #222.