### PR TITLE
fix(apply): disable spurious mkdir warning with magic rollback

### DIFF
--- a/internal/activation/supervisor.sh
+++ b/internal/activation/supervisor.sh
@@ -3,7 +3,8 @@
 # The activation directories may not exist at this point,
 # and creating the lockfile/triggers would fail otherwise.
 mkdir -p /run/nixos
-mkdir -m 1777 /run/nixos/trigger
+# shellcheck disable=SC2174
+mkdir -p -m 1777 /run/nixos/trigger
 
 # Concurrent supervisors are prohibited.
 # Otherwise, multiple rollbacks and switch-to-configuration


### PR DESCRIPTION
`mkdir /run/nixos/trigger` in the activation supervisor script was emitting a spurious error when the directory already existed.

This PR adds `-p` to the call to suppress this.