### PR TITLE
chore(deps): upgrade optnix -> v0.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0
 	modernc.org/sqlite v1.46.1
-	snare.dev/optnix v0.3.1
+	snare.dev/optnix v0.3.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -290,5 +290,5 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
-snare.dev/optnix v0.3.1 h1:W5mlqubazK2SyvPObE7vk10tkNDklccniFnDyQf4kX8=
-snare.dev/optnix v0.3.1/go.mod h1:GyNC5EYxp5EKxMP2wNXWZx0LgYuqAQP17jUj8pRRz+g=
+snare.dev/optnix v0.3.2 h1:JxYrT+h1YLRqDZcDXgNfhqM8sYZd2N4jCKYmuWyHuYc=
+snare.dev/optnix v0.3.2/go.mod h1:J5pLUCEHH+k7oWl8xf4WDTcnNwDnoocuYk/vr3qB+Wo=

--- a/nix/package/unwrapped.nix
+++ b/nix/package/unwrapped.nix
@@ -24,7 +24,7 @@ buildGo126Module (finalAttrs: {
     ];
   };
 
-  vendorHash = "sha256-a5BmkR5dKdV9di+GfckYVDu+PNbQmdEUCdOzkQcucYQ=";
+  vendorHash = "sha256-nOGOu5gEAeHJ/LEKvrHRwWEneb7VUJWO7Vr2h7F1ri4=";
 
   nativeBuildInputs = [installShellFiles scdoc];
 


### PR DESCRIPTION
Upgrades the `optnix` dependency to integrate newly released clipboard copying support.