### PR TITLE
feat(ssh): resolve host aliases through ssh_config

### DIFF
--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	shlex "github.com/carapace-sh/carapace-shlex"
+	ssh_config "github.com/kevinburke/ssh_config"
 	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
@@ -94,25 +95,53 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 		return nil, err
 	}
 
+	// Resolve hostInfo.Host against the user's ssh_config so host aliases
+	// (e.g. `Host prod \n  HostName 10.0.0.1 \n  User admin \n  Port 2222`)
+	// dial the real endpoint the way OpenSSH would. Explicit values from
+	// the command-line host string (user@, :port) still take precedence
+	// over ssh_config entries; we only consult ssh_config for fields the
+	// caller did not set.
+	var configuredHostName, configuredUser, configuredPort string
+	if hostInfo.Host != "" {
+		configuredHostName = ssh_config.Get(hostInfo.Host, "HostName")
+		configuredUser = ssh_config.Get(hostInfo.Host, "User")
+		configuredPort = ssh_config.Get(hostInfo.Host, "Port")
+	}
+
 	var username string
 	var address string
 	var port int
 
 	if hostInfo.User == "" {
-		var currentUser string
-		currentUser, err = utils.GetUsername()
-		if err != nil {
-			return nil, err
+		if configuredUser != "" {
+			username = configuredUser
+		} else {
+			var currentUser string
+			currentUser, err = utils.GetUsername()
+			if err != nil {
+				return nil, err
+			}
+			username = currentUser
 		}
-		username = currentUser
 	} else {
 		username = hostInfo.User
 	}
 
 	address = hostInfo.Host
+	if configuredHostName != "" {
+		address = configuredHostName
+	}
 
 	if hostInfo.Port != 0 {
 		port = hostInfo.Port
+	} else if configuredPort != "" {
+		p, parseErr := strconv.Atoi(configuredPort)
+		if parseErr != nil || p <= 0 || p > 65535 {
+			log.Warnf("ignoring invalid Port %q in ssh_config for %q", configuredPort, hostInfo.Host)
+			port = 22
+		} else {
+			port = p
+		}
 	} else {
 		port = 22
 	}


### PR DESCRIPTION
## Summary
Honour `Host alias` / `HostName` / `User` / `Port` entries from the user's `~/.ssh/config` when `NewSSHConfig` parses a `--target-host` / `--build-host` argument. Command-line precedence (explicit `user@` and `:port`) is preserved; `ssh_config` only fills the fields the caller did not set.

## Why this matters
Issue #226 points at the gap between completion (#186) and connection. Completion already enumerates SSH hosts via `internal/ssh/config.go` which uses `github.com/kevinburke/ssh_config`. The connection side at `internal/system/ssh.go:NewSSHConfig` didn't - it would dial literally whatever alias the user typed on the port/user the parser returned, which fails when the alias isn't a resolvable DNS name (common for internal hosts behind a jump box, internal DNS, etc.).

`nixos apply --target-host prod` would fail against:
```
Host prod
  HostName 10.0.0.1
  User admin
  Port 2222
```
because `prod:22` doesn't resolve. With this change, the same library already in use resolves the alias and dials `10.0.0.1:2222` as `admin`.

## Changes
- `internal/system/ssh.go`:
  - Import `github.com/kevinburke/ssh_config` (already in `go.mod` / `go.sum` via the completion path, so no new dependency).
  - After `ParseUserHostPort`, look up `HostName` / `User` / `Port` in ssh_config using the parsed host as the alias.
  - Override `username` only if the caller did not pass `user@`.
  - Override `address` with `HostName` whenever ssh_config returns one (the primary use case).
  - Override `port` only if the caller did not pass `:port`. A non-parseable or out-of-range `Port` in the config is warned via the existing logger and falls back to `22` - matching OpenSSH's "use the default if the config is bad" behaviour rather than erroring the whole dial.

## Testing
```
$ go build ./...
$ go vet ./...
$ go test ./internal/ssh/... ./internal/system/...
ok  	github.com/nix-community/nixos-cli/internal/ssh	0.348s
ok  	github.com/nix-community/nixos-cli/internal/system	0.230s
```

The change is backward-compatible for users without an ssh_config match: `ssh_config.Get` returns `""` for every unknown alias/key, so none of the override branches fire and `NewSSHConfig` behaves exactly as before.

Fixes #226

This contribution was developed with AI assistance (Claude Code).
