### PR TITLE
docs: add AI contribution policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,34 @@ prerequisite for every patch or pull request to be merged.
 Cache artifacts are published in a Cachix cache at https://watersucks.cachix.org
 when a release is triggered.
 
+## AI Policy
+
+All contributions made to `nixos-cli` are appreciated. However, quality becomes
+a concern when AI is involved.
+
+AI is a tool in the developer toolbox, and is used for code review, courtesy of
+CodeRabbit and their OSS program. As such, AI usage is not prohibited, but
+proper standards must be enforced to prevent the repository from rotting.
+
+AI-assisted contributions will be accepted under three conditions:
+
+1. The contributor must **understand their code** and be able to explain it in
+   their pull request description and during the review process. AI-generated
+   descriptions, comments, etc. will be rejected without consideration.
+2. The contributor must demonstrate that their code works, either through proper
+   unit/integration tests, or with picture/video evidence.
+3. Autonomously-submitted code (via Claude Code or other such agentic AI tools)
+   will be automatically rejected without consideration. This kind of drive-by
+   contribution forces the maintainers to make the assumption that the
+   contributor did not do their due diligence described in the previous
+   conditions.
+
+Additionally, AI usage is _strictly prohibited_ for issues marked with the "good
+first issue" label. Those issues are meant for human contributors to get a good
+grasp on the codebase by doing the work on their own; using AI to do this
+defeats the purpose and actively does the maintainers a disservice. Please also
+consider this when contributing to other open-source projects.
+
 ## Talk!
 
 Join the Matrix room at

--- a/doc/src/contributing.md
+++ b/doc/src/contributing.md
@@ -32,12 +32,40 @@ following things:
 - Settings
 - NixOS module options
 
+## AI Policy
+
+All contributions made to `nixos-cli` are appreciated. However, quality becomes
+a concern when AI is involved.
+
+AI is a tool in the developer toolbox, and is used for code review, courtesy of
+CodeRabbit and their OSS program. As such, AI usage is not prohibited, but
+proper standards must be enforced to prevent the repository from rotting.
+
+AI-assisted contributions will be accepted under three conditions:
+
+1. The contributor must **understand their code** and be able to explain it in
+   their pull request description and during the review process. AI-generated
+   descriptions, comments, etc. will be rejected without consideration.
+2. The contributor must demonstrate that their code works, either through proper
+   unit/integration tests, or with picture/video evidence.
+3. Autonomously-submitted code (via Claude Code or other such agentic AI tools)
+   will be automatically rejected without consideration. This kind of drive-by
+   contribution forces the maintainers to make the assumption that the
+   contributor did not do their due diligence described in the previous
+   conditions.
+
+Additionally, AI usage is _strictly prohibited_ for issues marked with the "good
+first issue" label. Those issues are meant for human contributors to get a good
+grasp on the codebase by doing the work on their own; using AI to do this
+defeats the purpose and actively does the maintainers a disservice. Please also
+consider this when contributing to other open-source projects.
+
 ## Bug Reports
 
 Testing every feature edge-case is hard—especially before full releases.
 
 If you're a brave soul, use the main branch instead of a release version, and
-file bug reports by
+file any bug reports by
 [opening a new issue](https://github.com/nix-community/nixos-cli/issues) with
 the **Bug Report** template. In the bug report, provide:
 
@@ -47,11 +75,11 @@ the **Bug Report** template. In the bug report, provide:
 - Your environment (run `nixos features`)
 - Any relevant logs, error messages, or images
 
-Clear reports will assist in faster bug fixes!
+Clear reports will assist in faster resolution!
 
 ## Improving Documentation
 
-Nix documentation is notoriously patchy — so help here is _especially_ welcome.
+Nix documentation is notoriously patchy, so help here is _especially_ welcome.
 
 As such, documentation quality is of utmost importance. `nixos-cli` should be a
 tool that is both easy to use and powerful in functionality; however, as


### PR DESCRIPTION
Self-explanatory.

#227 forced me to consider future AI contributors. Frankly, I was visibly irritated when I saw someone open a PR to close an issue marked "good first issue" mere hours after I had filed it.

They had presumably never used the tool (or NixOS at large), and were looking for good first issues to contribute to in order to make their contribution graph green, because all the work was done with an agent. So not only did they not learn anything about the codebase, but they just prevented someone else from learning how to work in it because Claude did it for them.

It's unfortunate that I have to consider this kind of behavior, especially from people far more experienced than myself in the software industry, but I digress.